### PR TITLE
Update repo links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,4 +18,4 @@ for docstrings.
 
 ## Localization
 
-See [README](https://github.com/jmoiron/humanize#localization).
+See [README](https://github.com/python-humanize/humanize#localization).

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -2,7 +2,7 @@ name: Sync labels
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/labels.yml
   workflow_dispatch:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_release_draft:
-    if: github.repository_owner == 'jmoiron'
+    if: github.repository_owner == 'python-humanize'
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "master"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     if: github.repository_owner == 'python-humanize'
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next release notes as pull requests are merged into "master"
+      # Drafts your next release notes as pull requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/humanize.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/humanize/)
 [![Documentation Status](https://readthedocs.org/projects/python-humanize/badge/?version=latest)](https://python-humanize.readthedocs.io/en/latest/?badge=latest)
 [![PyPI downloads](https://img.shields.io/pypi/dm/humanize.svg)](https://pypistats.org/packages/humanize)
-[![GitHub Actions status](https://github.com/jmoiron/humanize/workflows/Test/badge.svg)](https://github.com/jmoiron/humanize/actions)
-[![codecov](https://codecov.io/gh/hugovk/humanize/branch/master/graph/badge.svg)](https://codecov.io/gh/hugovk/humanize)
-[![MIT License](https://img.shields.io/github/license/jmoiron/humanize.svg)](LICENCE)
+[![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
+[![codecov](https://codecov.io/gh/python-humanize/humanize/branch/master/graph/badge.svg)](https://codecov.io/gh/python-humanize/humanize)
+[![MIT License](https://img.shields.io/github/license/python-humanize/humanize.svg)](LICENCE)
 [![Tidelift](https://tidelift.com/badges/package/pypi/humanize)](https://tidelift.com/subscription/pkg/pypi-humanize?utm_source=pypi-humanize&utm_medium=badge)
 
 This modest package contains various common humanization utilities, like turning

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation Status](https://readthedocs.org/projects/python-humanize/badge/?version=latest)](https://python-humanize.readthedocs.io/en/latest/?badge=latest)
 [![PyPI downloads](https://img.shields.io/pypi/dm/humanize.svg)](https://pypistats.org/packages/humanize)
 [![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
-[![codecov](https://codecov.io/gh/python-humanize/humanize/branch/master/graph/badge.svg)](https://codecov.io/gh/python-humanize/humanize)
+[![codecov](https://codecov.io/gh/python-humanize/humanize/branch/main/graph/badge.svg)](https://codecov.io/gh/python-humanize/humanize)
 [![MIT License](https://img.shields.io/github/license/python-humanize/humanize.svg)](LICENCE)
 [![Tidelift](https://tidelift.com/badges/package/pypi/humanize)](https://tidelift.com/subscription/pkg/pypi-humanize?utm_source=pypi-humanize&utm_medium=badge)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,16 +1,16 @@
 # Release Checklist
 
 - [ ] Get master to the appropriate code release state.
-      [GitHub Actions](https://github.com/jmoiron/humanize/actions) should be running
+      [GitHub Actions](https://github.com/python-humanize/humanize/actions) should be running
       cleanly for all merges to master.
-      [![GitHub Actions status](https://github.com/jmoiron/humanize/workflows/Test/badge.svg)](https://github.com/jmoiron/humanize/actions)
+      [![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
 
 * [ ] Start from a freshly cloned repo:
 
 ```bash
 cd /tmp
 rm -rf humanize
-git clone https://github.com/jmoiron/humanize
+git clone https://github.com/python-humanize/humanize
 cd humanize
 # Generate translation binaries
 scripts/generate-translation-binaries.sh
@@ -61,7 +61,7 @@ python3 -c "import humanize; print(humanize.__version__)"
 git push --tags
 ```
 
-* [ ] Edit release draft, adjust text if needed: https://github.com/jmoiron/humanize/releases
+* [ ] Edit release draft, adjust text if needed: https://github.com/python-humanize/humanize/releases
 
 * [ ] Check next tag is correct, amend if needed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Release Checklist
 
-- [ ] Get master to the appropriate code release state.
+- [ ] Get `main` to the appropriate code release state.
       [GitHub Actions](https://github.com/python-humanize/humanize/actions) should be running
-      cleanly for all merges to master.
+      cleanly for all merges to `main`.
       [![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
 
 * [ ] Start from a freshly cloned repo:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: humanize
 site_url: https://python-humanize.readthedocs.io
-repo_url: https://github.com/jmoiron/humanize
+repo_url: https://github.com/python-humanize/humanize
 theme:
   name: material
   palette:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = humanize
 description = Python humanize utilities
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/jmoiron/humanize
+url = https://github.com/python-humanize/humanize
 author = Jason Moiron
 author_email = jmoiron@jmoiron.net
 maintainer = Hugo van Kemenade
@@ -27,11 +27,11 @@ classifiers =
     Topic :: Text Processing :: General
 keywords = humanize time size
 project_urls =
-    Source=https://github.com/jmoiron/humanize
-    Issue tracker=https://github.com/jmoiron/humanize/issues
+    Source=https://github.com/python-humanize/humanize
+    Issue tracker=https://github.com/python-humanize/humanize/issues
     Funding=https://tidelift.com/subscription/pkg/pypi-humanize?utm_source=pypi-humanize&utm_medium=pypi
     Documentation=https://python-humanize.readthedocs.io/
-    Release notes=https://github.com/jmoiron/humanize/releases
+    Release notes=https://github.com/python-humanize/humanize/releases
 
 [options]
 packages = find:

--- a/src/humanize/locale/da_DK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/da_DK/LC_MESSAGES/humanize.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
-"Report-Msgid-Bugs-To: https://github.com/jmoiron/humanize/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/python-humanize/humanize/issues\n"
 "POT-Creation-Date: 2021-07-05 09:49+0200\n"
 "PO-Revision-Date: 2021-11-24 22:25+0200\n"
 "Last-Translator: YURII DEREVYCH <gkhelloworld@gmail.com>\n"

--- a/src/humanize/locale/sv_SE/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sv_SE/LC_MESSAGES/humanize.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
-"Report-Msgid-Bugs-To: https://github.com/jmoiron/humanize/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/python-humanize/humanize/issues\n"
 "POT-Creation-Date: 2021-07-05 09:49+0200\n"
 "PO-Revision-Date: 2021-07-05 10:30+0200\n"
 "Last-Translator: Kess Vargavind <vargavind@gmail.com>\n"


### PR DESCRIPTION
Changes proposed in this pull request:

* Repo now at https://github.com/python-humanize/humanize
* Also using `main` as the default branch
