### PR TITLE
Create success job for automerge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,11 @@ jobs:
         with:
           flags: ${{ matrix.codecov-flag }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+  success:
+    needs: test
+    runs-on: ubuntu-latest
+    name: test successful
+    steps:
+      - name: Success
+        run: echo Test successful


### PR DESCRIPTION
For #3.

Changes proposed in this pull request:

* This creates a no-op "test successful" job, that only runs when the test matrix is successful
* Then automerge can have this success job as a required status check in the branch protection rules
* Means we don't need to tediously add/remove individual matrix entries as they change

![image](https://user-images.githubusercontent.com/1324225/163402541-622d29b5-6dde-4f57-8025-171c62bc6f4d.png)
