### PR TITLE
GHA: add workflow to require changelog label

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -1,0 +1,18 @@
+name: Require PR label
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels:
+            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
+            Fixed, changelog: Removed, changelog: Security, changelog: skip"


### PR DESCRIPTION
For #3.

Changes proposed in this pull request:

* This requires one of the "changelog: X" labels to be added
* Those labels are used by release drafter to draft the release, and also figure out the next release number
* And we can add it make it a required check too so it's not forgotten
