### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          # Include new variables for Codecov
-          - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
-          - { codecov-flag: GHA_macOS, os: macos-latest }
-          - { codecov-flag: GHA_Windows, os: windows-latest }
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -56,7 +51,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          flags: ${{ matrix.codecov-flag }}
+          flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
   success:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,21 @@ repos:
         args: ["--convention", "google"]
         files: "src/"
 
-  - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.2
-    hooks:
-      - id: tox-ini-fmt
-
   - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
+        args: [--max-py-version=3.11]
+
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: 0.3.3
+    hooks:
+      - id: pyproject-fmt
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 0.5.2
+    hooks:
+      - id: tox-ini-fmt
 
 ci:
   autoupdate_schedule: quarterly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=42",
+  "setuptools_scm[toml]>=3.4",
+  "wheel",
+]
 
 [tool.black]
 target_version = ["py37"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{py3, 310, 39, 38, 37}
+    py{py3, 311, 310, 39, 38, 37}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Python 3.11 beta is out on Friday with full release in October:

* 3.11.0 beta 1: Friday, 2022-05-06
* 3.11.0 final: Monday, 2022-10-03

https://peps.python.org/pep-0664/

Changes proposed in this pull request:

 * Test `3.11-dev` on GitHub Actions
 * Add `py311` to `tox.ini`
 * Add Trove classifier
 * Update some config
