### PR TITLE
Remove redundant `wheel` dependency from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=42",
   "setuptools_scm[toml]>=3.4",
-  "wheel",
 ]
 
 [tool.black]


### PR DESCRIPTION
The `wheel` dependency in `pyproject.toml` is not necessary, and modern
setuptools documentation advises against adding it.  The PEP517 backend
automatically exposes the `wheel` dependency, and a future version
of setuptools may no longer use it.