### PR TITLE
BUG: Use %d for year translations convert to string for intcomma after

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -202,7 +202,7 @@ def naturaldelta(
         else:
             return _ngettext("1 year, %d day", "1 year, %d days", days) % days
 
-    return _ngettext("%s year", "%s years", years) % intcomma(years)
+    return _ngettext("%d year", "%d years", years).replace("%d", "%s") % intcomma(years)
 
 
 def naturaltime(

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -52,6 +52,23 @@ def test_intcomma() -> None:
         humanize.i18n.deactivate()
         assert humanize.intcomma(number) == "10,000,000"
 
+def test_naturaldelta() -> None:
+    seconds = 1234 * 365 * 24 * 60 * 60
+
+    assert humanize.naturaldelta(seconds) == "1,234 years"
+
+    try:
+        humanize.i18n.activate("fr_FR")
+        assert humanize.naturaldelta(seconds) == "1 234 ans"
+        humanize.i18n.activate("es_ES")
+        assert humanize.naturaldelta(seconds) == "1,234 años"
+
+    except FileNotFoundError:
+        pytest.skip("Generate .mo with scripts/generate-translation-binaries.sh")
+
+    finally:
+        humanize.i18n.deactivate()
+        assert humanize.naturaldelta(seconds) == "1,234 years"
 
 @pytest.mark.parametrize(
     ("locale", "number", "expected_result"),

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -52,6 +52,7 @@ def test_intcomma() -> None:
         humanize.i18n.deactivate()
         assert humanize.intcomma(number) == "10,000,000"
 
+
 def test_naturaldelta() -> None:
     seconds = 1234 * 365 * 24 * 60 * 60
 
@@ -69,6 +70,7 @@ def test_naturaldelta() -> None:
     finally:
         humanize.i18n.deactivate()
         assert humanize.naturaldelta(seconds) == "1,234 years"
+
 
 @pytest.mark.parametrize(
     ("locale", "number", "expected_result"),


### PR DESCRIPTION
This patch fixes a bug introduced in 3.14.0, where the format
string was changed from %d to %s to add separators to the year.
However, this needs to happen after translation because the
translator uses the format strings as part of the translation.

Closes #21