### PR TITLE
Update annotations: naturadelta and naturaltime can also accept a float

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -55,22 +55,22 @@ def naturalsize(
         suffix = suffixes["decimal"]
 
     base = 1024 if (gnu or binary) else 1000
-    bytes = float(value)
-    abs_bytes = abs(bytes)
+    bytes_ = float(value)
+    abs_bytes = abs(bytes_)
 
     if abs_bytes == 1 and not gnu:
-        return "%d Byte" % bytes
+        return "%d Byte" % bytes_
     elif abs_bytes < base and not gnu:
-        return "%d Bytes" % bytes
+        return "%d Bytes" % bytes_
     elif abs_bytes < base and gnu:
-        return "%dB" % bytes
+        return "%dB" % bytes_
 
     for i, s in enumerate(suffix):
         unit = base ** (i + 2)
         if abs_bytes < unit and not gnu:
-            return (format + " %s") % ((base * bytes / unit), s)
+            return (format + " %s") % ((base * bytes_ / unit), s)
         elif abs_bytes < unit and gnu:
-            return (format + "%s") % ((base * bytes / unit), s)
+            return (format + "%s") % ((base * bytes_ / unit), s)
     if gnu:
-        return (format + "%s") % ((base * bytes / unit), s)
-    return (format + " %s") % ((base * bytes / unit), s)
+        return (format + "%s") % ((base * bytes_ / unit), s)
+    return (format + " %s") % ((base * bytes_ / unit), s)

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -88,7 +88,7 @@ def _date_and_delta(
 
 
 def naturaldelta(
-    value: dt.timedelta | int,
+    value: dt.timedelta | float,
     months: bool = True,
     minimum_unit: str = "seconds",
 ) -> str:
@@ -97,7 +97,7 @@ def naturaldelta(
     This is similar to `naturaltime`, but does not add tense to the result.
 
     Args:
-        value (datetime.timedelta or int): A timedelta or a number of seconds.
+        value (datetime.timedelta, int or float): A timedelta or a number of seconds.
         months (bool): If `True`, then a number of months (based on 30.5 days) will be
             used for fuzziness between years.
         minimum_unit (str): The lowest unit that can be used.
@@ -206,7 +206,7 @@ def naturaldelta(
 
 
 def naturaltime(
-    value: dt.datetime | int,
+    value: dt.datetime | float,
     future: bool = False,
     months: bool = True,
     minimum_unit: str = "seconds",
@@ -217,7 +217,7 @@ def naturaltime(
     This is more or less compatible with Django's `naturaltime` filter.
 
     Args:
-        value (datetime.datetime, int): A `datetime` or a number of seconds.
+        value (datetime.datetime, int or float): A `datetime` or a number of seconds.
         future (bool): Ignored for `datetime`s, where the tense is always figured out
             based on the current time. For integers, the return value will be past tense
             by default, unless future is `True`.

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -93,6 +93,7 @@ def test_naturaldelta_nomonths(test_input: dt.timedelta, expected: str) -> None:
     [
         (0, "a moment"),
         (1, "a second"),
+        (23.5, "23 seconds"),
         (30, "30 seconds"),
         (dt.timedelta(minutes=1, seconds=30), "a minute"),
         (dt.timedelta(minutes=2), "2 minutes"),
@@ -156,6 +157,7 @@ def test_naturaldelta(test_input: int | dt.timedelta, expected: str) -> None:
         # regression tests for bugs in post-release humanize
         (NOW + dt.timedelta(days=10000), "27 years from now"),
         (NOW - dt.timedelta(days=365 + 35), "1 year, 1 month ago"),
+        (23.5, "23 seconds ago"),
         (30, "30 seconds ago"),
         (NOW - dt.timedelta(days=365 * 2 + 65), "2 years ago"),
         (NOW - dt.timedelta(days=365 + 4), "1 year, 4 days ago"),


### PR DESCRIPTION
For https://github.com/python-humanize/humanize/issues/28.

Changes proposed in this pull request:

* `naturadelta` and `naturaltime` can also accept a `float`
* Do not shadow `bytes` builtin
