### PR TITLE
Update annotations, docs, and tests: naturaltime can also accept a timedelta

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -206,7 +206,7 @@ def naturaldelta(
 
 
 def naturaltime(
-    value: dt.datetime | float,
+    value: dt.datetime | dt.timedelta | float,
     future: bool = False,
     months: bool = True,
     minimum_unit: str = "seconds",
@@ -217,10 +217,11 @@ def naturaltime(
     This is more or less compatible with Django's `naturaltime` filter.
 
     Args:
-        value (datetime.datetime, int or float): A `datetime` or a number of seconds.
-        future (bool): Ignored for `datetime`s, where the tense is always figured out
-            based on the current time. For integers, the return value will be past tense
-            by default, unless future is `True`.
+        value (datetime.datetime, datetime.timedelta, int or float): A `datetime`, a
+            `timedelta`, or a number of seconds.
+        future (bool): Ignored for `datetime`s and `timedelta`s, where the tense is
+            always figured out based on the current time. For integers and floats, the
+            return value will be past tense by default, unless future is `True`.
         months (bool): If `True`, then a number of months (based on 30.5 days) will be
             used for fuzziness between years.
         minimum_unit (str): The lowest unit that can be used.

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -157,6 +157,8 @@ def test_naturaldelta(test_input: int | dt.timedelta, expected: str) -> None:
         # regression tests for bugs in post-release humanize
         (NOW + dt.timedelta(days=10000), "27 years from now"),
         (NOW - dt.timedelta(days=365 + 35), "1 year, 1 month ago"),
+        (dt.timedelta(days=-10000), "27 years from now"),
+        (dt.timedelta(days=365 + 35), "1 year, 1 month ago"),
         (23.5, "23 seconds ago"),
         (30, "30 seconds ago"),
         (NOW - dt.timedelta(days=365 * 2 + 65), "2 years ago"),
@@ -200,6 +202,9 @@ def nt_nomonths(d: dt.datetime) -> str:
         # regression tests for bugs in post-release humanize
         (NOW + dt.timedelta(days=10000), "27 years from now"),
         (NOW - dt.timedelta(days=365 + 35), "1 year, 35 days ago"),
+        (dt.timedelta(days=-10000), "27 years from now"),
+        (dt.timedelta(days=365 + 35), "1 year, 35 days ago"),
+        (23.5, "23 seconds ago"),
         (30, "30 seconds ago"),
         (NOW - dt.timedelta(days=365 * 2 + 65), "2 years ago"),
         (NOW - dt.timedelta(days=365 + 4), "1 year, 4 days ago"),


### PR DESCRIPTION
For #28.

Changes proposed in this pull request:

* `naturaltime` can also accept a `timedelta`
