### PR TITLE
Fix markdown issue and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,15 +207,15 @@ FileNotFoundError: [Errno 2] No translation file found for domain: 'humanize'
 
 How to add new phrases to existing locale files:
 
-```console
-$ xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -l python src/humanize/*.py  # extract new phrases
-$ msgmerge -U src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po humanize.pot # add them to locale files
+```sh
+xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -l python src/humanize/*.py  # extract new phrases
+msgmerge -U src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po humanize.pot # add them to locale files
 ```
 
 How to add a new locale:
 
-```console
-$ msginit -i humanize.pot -o humanize/locale/<locale name>/LC_MESSAGES/humanize.po --locale <locale name>
+```sh
+msginit -i humanize.pot -o humanize/locale/<locale name>/LC_MESSAGES/humanize.po --locale <locale name>
 ```
 
 Where `<locale name>` is a locale abbreviation, eg. `en_GB`, `pt_BR` or just `ru`, `fr`

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -376,7 +376,7 @@ def _suitable_minimum_unit(min_unit: Unit, suppress: typing.Iterable[Unit]) -> U
     >>> _suitable_minimum_unit(Unit.HOURS, []).name
     'HOURS'
 
-    But if suppressed, find a unit greather than the original one that is not
+    But if suppressed, find a unit greater than the original one that is not
     suppressed:
 
     >>> _suitable_minimum_unit(Unit.HOURS, [Unit.HOURS]).name


### PR DESCRIPTION
Resolve MD014 Dollar signs used before commands without showing output
See https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

