### PR TITLE
Fix "ValueError: math domain error" for metric(0)

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -508,7 +508,7 @@ def metric(value: float, unit: str = "", precision: int = 3) -> str:
     Returns:
         str:
     """
-    exponent = int(math.floor(math.log10(abs(value))))
+    exponent = int(math.floor(math.log10(abs(value)))) if value != 0 else 0
 
     if exponent >= 27 or exponent < -24:
         return scientific(value, precision - 1) + unit

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -194,6 +194,7 @@ def test_clamp(test_args: list[typing.Any], expected: str) -> None:
 @pytest.mark.parametrize(
     "test_args, expected",
     [
+        ([0], "0.00"),
         ([1, "Hz"], "1.00 Hz"),
         ([1.0, "W"], "1.00 W"),
         ([3, "C"], "3.00 C"),


### PR DESCRIPTION
Call metrics(0) gives `ValueError: math domain error` before this patch.
