### PR TITLE
Internationalise intcomma for de_DE locale

### DIFF
--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -15,6 +15,7 @@ _CURRENT = local()
 
 # Mapping of locale to thousands separator
 _THOUSANDS_SEPARATOR = {
+    "de_DE": ".",
     "fr_FR": " ",
 }
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -42,6 +42,8 @@ def test_intcomma() -> None:
     assert humanize.intcomma(number) == "10,000,000"
 
     try:
+        humanize.i18n.activate("de_DE")
+        assert humanize.intcomma(number) == "10.000.000"
         humanize.i18n.activate("fr_FR")
         assert humanize.intcomma(number) == "10 000 000"
 


### PR DESCRIPTION
See discussion in #48.

Changes proposed in this pull request:

* Add the proper thousands separator for the de_DE locale
* Add a simple test