### PR TITLE
Update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -31,7 +31,7 @@ repos:
         files: \.py$
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -58,20 +58,20 @@ repos:
         files: "src/"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.971
     hooks:
       - id: mypy
         additional_dependencies: [pytest, types-freezegun, types-setuptools]
         args: [--strict]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
-        args: [--max-py-version=3.11]
+        args: [--max-py-version=3.11, --include-version-classifiers]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.3.4
+    rev: 0.3.5
     hooks:
       - id: pyproject-fmt
 


### PR DESCRIPTION
* Update `pyproject-fmt` to fix "TypeError: 'Whitespace' object is not iterable" https://github.com/tox-dev/pyproject-fmt/issues/32

* Add `--include-version-classifiers` to keep Trove classifiers with newest `setup-cfg-fmt`: https://github.com/asottile/setup-cfg-fmt#adds-python-version-classifiers
