### PR TITLE
Stabilize test name for tests using FakeDate

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -35,7 +35,7 @@ with freeze_time("2020-02-02"):
 class FakeDate:
     def __init__(self, year: int, month: int, day: int) -> None:
         self.year, self.month, self.day = year, month, day
-        
+
     def __str__(self):
         return f"{self.year}-{self.month}-{self.day}"
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -36,7 +36,7 @@ class FakeDate:
     def __init__(self, year: int, month: int, day: int) -> None:
         self.year, self.month, self.day = year, month, day
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.year}-{self.month}-{self.day}"
 
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -35,6 +35,9 @@ with freeze_time("2020-02-02"):
 class FakeDate:
     def __init__(self, year: int, month: int, day: int) -> None:
         self.year, self.month, self.day = year, month, day
+        
+    def __str__(self):
+        return f"{self.year}-{self.month}-{self.day}"
 
 
 VALUE_ERROR_TEST = FakeDate(290149024, 2, 2)


### PR DESCRIPTION
This makes test name stable and thus suitable to run in CI systems, which use test name as test identifiers.
