### PR TITLE
Test on 3.11 instead of 3.11-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Fixes #67

Changes proposed in this pull request:

*  Test on 3.11 instead of 3.11-dev, by replacing 3.11-dev to 3.11 in .github/workflows/test.yml
* 
* 
