### PR TITLE
Replace setuptools with hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ target_version = ["py37"]
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build]
+include = [
+  "src/humanize/locale/**/*.mo",
+]
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ target_version = ["py37"]
 version.source = "vcs"
 
 [tool.hatch.build]
-include = [
-  "src/humanize/locale/**/*.mo",
+artifacts = [
+  "*.mo",
 ]
 
 [tool.hatch.version.raw-options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
-build-backend = "setuptools.build_meta"
+build-backend = "hatchling.build"
 requires = [
-  "setuptools>=61.2",
-  "setuptools_scm[toml]>=6.2",
+  "hatch-vcs",
+  "hatchling",
 ]
 
 [project]
@@ -62,6 +62,9 @@ target_version = ["py37"]
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
 [tool.isort]
 profile = "black"
 
@@ -70,10 +73,3 @@ convention = "google"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"
-
-[tool.setuptools.packages.find]
-where = ["src"]
-namespaces = false
-
-[tool.setuptools_scm]
-local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from setuptools import setup
-
-setup(
-    setup_requires=["setuptools_scm"],
-)


### PR DESCRIPTION
Changes proposed in this pull request:

* Replace setuptools with hatchling
* Replace setuptools_scm with hatch-vcs
* Include translation `.mo` files as artifacts
* Delete `setup.py` (`setup.cfg` was deleted in #90)

