### PR TITLE
Add missing keys to extract translatable strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ FileNotFoundError: [Errno 2] No translation file found for domain: 'humanize'
 How to add new phrases to existing locale files:
 
 ```sh
-xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -l python src/humanize/*.py  # extract new phrases
+xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -k'_ngettext:1,2' -l python src/humanize/*.py  # extract new phrases
 msgmerge -U src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po humanize.pot # add them to locale files
 ```
 

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -1,7 +1,7 @@
 set -e
 
 # extract new phrases
-/usr/local/opt/gettext/bin/xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -l python src/humanize/*.py
+/usr/local/opt/gettext/bin/xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -k'_ngettext:1,2' -l python src/humanize/*.py
 
 for d in src/humanize/locale/*/; do
     locale="$(basename $d)"

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -1,13 +1,13 @@
 set -e
 
 # extract new phrases
-/usr/local/opt/gettext/bin/xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -k'_ngettext:1,2' -l python src/humanize/*.py
+xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -k'_ngettext:1,2' -l python src/humanize/*.py
 
 for d in src/humanize/locale/*/; do
     locale="$(basename $d)"
     echo "$locale"
     # add them to locale files
-    /usr/local/opt/gettext/bin/msgmerge -U src/humanize/locale/$locale/LC_MESSAGES/humanize.po humanize.pot
+    msgmerge -U src/humanize/locale/$locale/LC_MESSAGES/humanize.po humanize.pot
     # compile to binary .mo
-    /usr/local/opt/gettext/bin/msgfmt --check -o src/humanize/locale/$locale/LC_MESSAGES/humanize{.mo,.po}
+    msgfmt --check -o src/humanize/locale/$locale/LC_MESSAGES/humanize{.mo,.po}
 done

--- a/src/humanize/locale/ar/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ar/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-13 17:27+0300\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2022-04-13 17:28+0300\n"
 "Last-Translator: AYMEN Mohammed <let.me.code.safe@gmail.com>\n"
 "Language-Team: Arabic <let.me.code.safe@gmail.com>\n"
@@ -17,341 +17,347 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "صفر"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "اول"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "ثاني"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "ثالث"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "رابع"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "خامس"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "سادس"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "سابع"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "ثامن"
 
-#: src/humanize/number.py:67
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "تاسع"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "صفر"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "اول"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ثاني"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ثالث"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "رابع"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "خامس"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "سادس"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "سابع"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ثامن"
 
-#: src/humanize/number.py:80
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "تاسع"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "الف"
 msgstr[1] "الاف"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "مليون"
 msgstr[1] "ملايين"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "مليار"
 msgstr[1] "مليارات"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "تريليون"
 msgstr[1] "تريليونات"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "كوادريليون"
 msgstr[1] "كوادريليون"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "كوينتيليون"
 msgstr[1] "كوينتيليون"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "سكستليون"
 msgstr[1] "سكستليون"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "سبتيليون"
 msgstr[1] "سبتيليون"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "اوكتيليون"
 msgstr[1] "اوكتيليون"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "نونليون"
 msgstr[1] "نونليون"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "ديليون"
 msgstr[1] "ديليون"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:189
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "صفر"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "واحد"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "اثنين"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "ثلاثه"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "اربعه"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "خمسه"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "سته"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "سبعه"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "ثمانيه"
 
-#: src/humanize/number.py:256
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "تسعه"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d ميكرو من الثانية"
 msgstr[1] "%d ميكرو من الثانية"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d جزء من الثانية"
 msgstr[1] "%d اجزاء من الثانية"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "لحظة"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "ثانية"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d ثانية"
 msgstr[1] "%d ثواني"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "دقيقة"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d دقيقة"
 msgstr[1] "%d دقائق"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "ساعة"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ساعة"
 msgstr[1] "%d ساعات"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "يوم"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d يوم"
 msgstr[1] "%d أيام"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "شهر"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d شهر"
 msgstr[1] "%d أشهر"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "سنة"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 سنة ، %d يوم"
 msgstr[1] "1 سنة ، %d ايام"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "سنة وشهر"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 سنة ، %d شهر"
 msgstr[1] "1 سنة ، %d اشهر"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d سنة"
 msgstr[1] "%d سنين"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s من الان"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "قبل %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "الان"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "اليوم"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "بكرة"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "أمس"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s و %s"

--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-29 21:59+0600\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2021-07-29 22:07+0600\n"
 "Last-Translator: U-WASI-PC\\Wasi Master <arianmollik323@gmail.com>\n"
 "Language-Team: Bengali\n"
@@ -17,275 +17,349 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr ""
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr ""
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr ""
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:67
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr ""
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr ""
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr ""
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:80
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr ""
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:178
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:179
+#, fuzzy
+msgid "million"
+msgid_plural "million"
+msgstr[0] "%d মিলিসেকন্ড"
+msgstr[1] "%d মিলিসেকন্ড"
+
+#: src/humanize/number.py:180
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:181
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:182
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:183
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:184
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:185
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:186
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:187
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:188
+#, fuzzy
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "%d মিলিসেকন্ড"
+msgstr[1] "%d মিলিসেকন্ড"
+
+#: src/humanize/number.py:189
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "শুন্য"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "এক"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "দুই"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "তিন"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "চার"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "পাচ"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "ছয়"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "সাত"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "আট"
 
-#: src/humanize/number.py:256
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "নয়"
 
-#: src/humanize/time.py:138
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d মাইক্রোসেকন্ড"
 msgstr[1] "%d মাইক্রোসেকন্ড"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d মিলিসেকন্ড"
 msgstr[1] "%d মিলিসেকন্ড"
 
-#: src/humanize/time.py:150 src/humanize/time.py:231
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "এক মুহুর্ত"
 
-#: src/humanize/time.py:152
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "এক সেকন্ড"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d সেকন্ড"
 msgstr[1] "%d সেকন্ড"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "এক মিনিট"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d মিনিট"
 msgstr[1] "%d মিনিট"
 
-#: src/humanize/time.py:161
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "এক ঘন্টা"
 
-#: src/humanize/time.py:164
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ঘন্টা"
 msgstr[1] "%d ঘন্টা"
 
-#: src/humanize/time.py:167
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "এক দিন"
 
-#: src/humanize/time.py:169 src/humanize/time.py:172
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d দিন"
 msgstr[1] "%d দিন"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "এক মাস"
 
-#: src/humanize/time.py:176
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d মাস"
 msgstr[1] "%d মাস"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "এক বছর"
 
-#: src/humanize/time.py:181 src/humanize/time.py:190
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "%d বছর"
 msgstr[1] "%d বছর"
 
-#: src/humanize/time.py:184
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "১ বছর, ১ মাস"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "১ বছর, %d মাস"
 msgstr[1] "১ বছর, %d মাস"
 
-#: src/humanize/time.py:192
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d বছর"
 msgstr[1] "%d বছর"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "আজ থেকে %s পরে"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s আগে"
 
-#: src/humanize/time.py:232
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "এখন"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "আজকে"
 
-#: src/humanize/time.py:257
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "আগামীকাল"
 
-#: src/humanize/time.py:259
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "গতকাল"
 
-#: src/humanize/time.py:545
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s আর  %s"

--- a/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ca_ES/LC_MESSAGES/humanize.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2021-04-09 19:57+0200\n"
 "Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
 "Language-Team: Catalan\n"
@@ -17,347 +17,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n!=1;\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milió"
 msgstr[1] "milió"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "mil milions"
 msgstr[1] "mil milions"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilions"
 msgstr[1] "bilions"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quadrilió"
 msgstr[1] "quadrilió"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillió"
 msgstr[1] "quintillió"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextilió"
 msgstr[1] "sextilió"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilió"
 msgstr[1] "septilió"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octilió"
 msgstr[1] "octilió"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilió"
 msgstr[1] "nonilió"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decilió"
 msgstr[1] "decilió"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinc"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sis"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "set"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "vuit"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nou"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microsegon"
 msgstr[1] "%d microsegons"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d mil·lisegons"
 msgstr[1] "%d mil·lisegons"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "un moment"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "un segon"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d segon"
 msgstr[1] "%d segons"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "un minut"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minuts"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "una hora"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d hora"
 msgstr[1] "%d hores"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "un dia"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dia"
 msgstr[1] "%d dies"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "un mes"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mes"
 msgstr[1] "%d mesos"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "un any"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 any, %d dia"
 msgstr[1] "1 any, %d dies"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 any, 1 mes"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 any, %d mes"
 msgstr[1] "1 any, %d mesos"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d any"
 msgstr[1] "%d anys"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "en %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "fa %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "ara"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "avui"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "demà"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ahir"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s i %s"

--- a/src/humanize/locale/da_DK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/da_DK/LC_MESSAGES/humanize.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
-"Report-Msgid-Bugs-To: https://github.com/python-humanize/humanize/issues\n"
-"POT-Creation-Date: 2021-07-05 09:49+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2021-11-24 22:25+0200\n"
 "Last-Translator: YURII DEREVYCH <gkhelloworld@gmail.com>\n"
 "Language-Team: Da\n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr ":e"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr ":t"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr ":e"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:67
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr ":e"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr ":t"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr ":e"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:80
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tusind"
 msgstr[1] "thousand"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "million"
 msgstr[1] "millioner"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "billion"
 msgstr[1] "billioner"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "billion"
 msgstr[1] "billioner"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quadrillion"
 msgstr[1] "quadrillioner"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillion"
 msgstr[1] "quintillioner"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextillion"
 msgstr[1] "sextillioner"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septillion"
 msgstr[1] "septillioner"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octillion"
 msgstr[1] "octillioner"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonillion"
 msgstr[1] "nonillioner"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decillion"
 msgstr[1] "decillioner"
 
-#: src/humanize/number.py:152
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nul"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "en"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "to"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tre"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "fire"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "fem"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "seks"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "syv"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "otte"
 
-#: src/humanize/number.py:256
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "ni"
 
-#: src/humanize/time.py:138
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d mikrosekund"
 msgstr[1] "%d mikrosekunder"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d millsekund"
 msgstr[1] "%d millsekunder"
 
-#: src/humanize/time.py:150 src/humanize/time.py:231
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "et øjeblik"
 
-#: src/humanize/time.py:152
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "en anden"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d sekund"
 msgstr[1] "%d sekunder"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "en minut"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minutter"
 
-#: src/humanize/time.py:161
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "en time"
 
-#: src/humanize/time.py:164
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d time"
 msgstr[1] "%d timer"
 
-#: src/humanize/time.py:167
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "en dag"
 
-#: src/humanize/time.py:169 src/humanize/time.py:172
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dag"
 msgstr[1] "%d dage"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "en måned"
 
-#: src/humanize/time.py:176
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d måned"
 msgstr[1] "%d måneder"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "et år"
 
-#: src/humanize/time.py:181 src/humanize/time.py:190
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 år, %d dag"
 msgstr[1] "1 år, %d dage"
 
-#: src/humanize/time.py:184
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 år, 1 måned"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 år, %d måned"
 msgstr[1] "1 år, %d måneder"
 
-#: src/humanize/time.py:192
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d år"
 msgstr[1] "%d år"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s fra nu"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s siden"
 
-#: src/humanize/time.py:232
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "nu"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "i dag"
 
-#: src/humanize/time.py:257
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "i morgen"
 
-#: src/humanize/time.py:259
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "i går"
 
-#: src/humanize/time.py:545
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s og %s"

--- a/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/de_DE/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2016-12-18 11:50+0100\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,347 +19,347 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Sublime Text 3\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "Million"
 msgstr[1] "Million"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "Milliarde"
 msgstr[1] "Milliarde"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "Billion"
 msgstr[1] "Billion"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "Billiarde"
 msgstr[1] "Billiarde"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "Trillion"
 msgstr[1] "Trillion"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "Trilliarde"
 msgstr[1] "Trilliarde"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "Quadrillion"
 msgstr[1] "Quadrillion"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "Quadrillarde"
 msgstr[1] "Quadrillarde"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "Quintillion"
 msgstr[1] "Quintillion"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "Quintilliarde"
 msgstr[1] "Quintilliarde"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "Googol"
 msgstr[1] "Googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "null"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "eins"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "zwei"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "drei"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "fünf"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sechs"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sieben"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "neun"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d Mikrosekunde"
 msgstr[1] "%d Mikrosekunden"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d Millisekunde"
 msgstr[1] "%d Millisekunden"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "ein Moment"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "eine Sekunde"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d Sekunde"
 msgstr[1] "%d Sekunden"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "eine Minute"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d Minute"
 msgstr[1] "%d Minuten"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "eine Stunde"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d Stunde"
 msgstr[1] "%d Stunden"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "ein Tag"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d Tag"
 msgstr[1] "%d Tage"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "ein Monat"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d Monat"
 msgstr[1] "%d Monate"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "ein Jahr"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "ein Jahr und %d Tag"
 msgstr[1] "ein Jahr und %d Tage"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "ein Monat"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "ein Jahr und %d Monat"
 msgstr[1] "ein Jahr und %d Monate"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d Jahr"
 msgstr[1] "%d Jahre"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s ab jetzt"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "vor %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "jetzt"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "heute"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "morgen"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "gestern"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s und %s"

--- a/src/humanize/locale/el_GR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/el_GR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 01:06+0300\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2022-08-05 01:09+0300\n"
 "Last-Translator: Isaak Tsalicoglou <isaak@waseigo.com>\n"
 "Language-Team: Greek <team@lists.gnome.gr>\n"
@@ -19,347 +19,427 @@ msgstr ""
 "Generated-By: Isaak Tsalicoglou\n"
 "X-Generator: Mousepad 0.5.9\n"
 
-#: src/humanize/number.py:71
-msgctxt "0 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:72
-msgctxt "1 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:73
-msgctxt "2 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:74
-msgctxt "3 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:75
-msgctxt "4 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:76
-msgctxt "5 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:77
-msgctxt "6 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:78
-msgctxt "7 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:79
-msgctxt "8 (male)"
-msgid "ος"
-msgstr "."
-
-#: src/humanize/number.py:80
-msgctxt "9 (male)"
-msgid "ος"
-msgstr "."
-
 #: src/humanize/number.py:84
-msgctxt "0 (female)"
-msgid "η"
-msgstr "."
+msgctxt "0 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:85
-msgctxt "1 (female)"
-msgid "η"
-msgstr "."
+msgctxt "1 (male)"
+msgid "st"
+msgstr ""
 
 #: src/humanize/number.py:86
-msgctxt "2 (female)"
-msgid "η"
-msgstr "."
+msgctxt "2 (male)"
+msgid "nd"
+msgstr ""
 
 #: src/humanize/number.py:87
-msgctxt "3 (female)"
-msgid "η"
-msgstr "."
+msgctxt "3 (male)"
+msgid "rd"
+msgstr ""
 
 #: src/humanize/number.py:88
-msgctxt "4 (female)"
-msgid "η"
-msgstr "."
+msgctxt "4 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:89
-msgctxt "5 (female)"
-msgid "η"
-msgstr "."
+msgctxt "5 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:90
-msgctxt "6 (female)"
-msgid "η"
-msgstr "."
+msgctxt "6 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:91
-msgctxt "7 (female)"
-msgid "η"
-msgstr "."
+msgctxt "7 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:92
-msgctxt "8 (female)"
-msgid "η"
-msgstr "."
+msgctxt "8 (male)"
+msgid "th"
+msgstr ""
 
 #: src/humanize/number.py:93
-msgctxt "9 (female)"
-msgid "η"
-msgstr "."
+msgctxt "9 (male)"
+msgid "th"
+msgstr ""
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:97
+msgctxt "0 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:98
+msgctxt "1 (female)"
+msgid "st"
+msgstr ""
+
+#: src/humanize/number.py:99
+msgctxt "2 (female)"
+msgid "nd"
+msgstr ""
+
+#: src/humanize/number.py:100
+msgctxt "3 (female)"
+msgid "rd"
+msgstr ""
+
+#: src/humanize/number.py:101
+msgctxt "4 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:102
+msgctxt "5 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:103
+msgctxt "6 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:104
+msgctxt "7 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:105
+msgctxt "8 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:106
+msgctxt "9 (female)"
+msgid "th"
+msgstr ""
+
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "χιλιάδα"
 msgstr[1] "χιλιάδες"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "εκατομμύριο"
 msgstr[1] "εκατομμύρια"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "δισεκατομμύριο"
 msgstr[1] "δισεκατομμύρια"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "τρισεκατομμύριο"
 msgstr[1] "τρισεκατομμύρια"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "τετράκις εκατομμύριο"
 msgstr[1] "τετράκις εκατομμύρια"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "πεντάκις εκατομμύριο"
 msgstr[1] "πεντάκις εκατομμύρια"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "εξάκις εκατομμύριο"
 msgstr[1] "εξάκις εκατομμύρια"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "επτάκις εκατομμύριο"
 msgstr[1] "επτάκις εκατομμύρια"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "οκτάκις εκατομμύριο"
 msgstr[1] "οκτάκις εκατομμύρια"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "εννεάκις εκατομμύριο"
 msgstr[1] "εννεάκις εκατομμύρια"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "δεκάκις εκατομμύριο"
 msgstr[1] "δεκάκις εκατομμύρια"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "δέκα τριακονταδυάκις εκατομμύριο"
 msgstr[1] "δέκα τριακονταδυάκις εκατομμύρια"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "μηδέν"
 
-#: src/humanize/number.py:275
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "ένα"
 
-#: src/humanize/number.py:276
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "δύο"
 
-#: src/humanize/number.py:277
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "τρία"
 
-#: src/humanize/number.py:278
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "τέσσερα"
 
-#: src/humanize/number.py:279
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "πέντε"
 
-#: src/humanize/number.py:280
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "έξι"
 
-#: src/humanize/number.py:281
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "επτά"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "οκτώ"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "εννέα"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d εκατομμυριοστό του δευτερολέπτου"
 msgstr[1] "%d εκατομμυριοστά του δευτερολέπτου"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d χιλιοστό του δευτερολέπτου"
 msgstr[1] "%d χιλιοστά του δευτερολέπτου"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "μια στιγμή"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "ένα δευτερόλεπτο"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d δευτερόλεπτο"
 msgstr[1] "%d δευτερόλεπτα"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "ένα λεπτό"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d λεπτό"
 msgstr[1] "%d λεπτά"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "μία ώρα"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ώρα"
 msgstr[1] "%d ώρες"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "μία ημέρα"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d ημέρα"
 msgstr[1] "%d ημέρες"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "ένα μήνα"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d μήνα"
 msgstr[1] "%d μήνες"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "ένα έτος"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "ένα έτος και %d ημέρα"
 msgstr[1] "ένα έτος και %d ημέρες"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "ένα έτος και ένα μήνα"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "ένα έτος και %d μήνα"
 msgstr[1] "ένα έτος και %d μήνες"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d έτος"
 msgstr[1] "%d έτη"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "σε %s από τώρα"
 
-#: src/humanize/time.py:242
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "πριν από %s"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "τώρα"
 
-#: src/humanize/time.py:269
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "σήμερα"
 
-#: src/humanize/time.py:271
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "αύριο"
 
-#: src/humanize/time.py:273
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "χθες"
 
-#: src/humanize/time.py:581
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s και %s"
+
+#~ msgctxt "0 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "1 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "2 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "3 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "4 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "5 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "6 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "7 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "8 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "9 (male)"
+#~ msgid "ος"
+#~ msgstr "."
+
+#~ msgctxt "0 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "1 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "2 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "3 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "4 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "5 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "6 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "7 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "8 (female)"
+#~ msgid "η"
+#~ msgstr "."
+
+#~ msgctxt "9 (female)"
+#~ msgid "η"
+#~ msgstr "."

--- a/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/es_ES/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2020-03-31 21:08+0200\n"
 "Last-Translator: Álvaro Mondéjar <mondejar1994@gmail.com>\n"
 "Language-Team: \n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ª"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ª"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ª"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "mil"
 msgstr[1] "mil"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "millón"
 msgstr[1] "millones"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "billón"
 msgstr[1] "billones"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trillón"
 msgstr[1] "trillones"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quatrillón"
 msgstr[1] "quatrillones"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillón"
 msgstr[1] "quintillones"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextillón"
 msgstr[1] "sextillones"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septillón"
 msgstr[1] "septillones"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octillón"
 msgstr[1] "octillones"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonillón"
 msgstr[1] "nonillones"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decillón"
 msgstr[1] "decillones"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "gúgol"
 msgstr[1] "gúgol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "cero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dos"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tres"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "cuatro"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "siete"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "ocho"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nueve"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microsegundo"
 msgstr[1] "%d microsegundos"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d milisegundo"
 msgstr[1] "%d milisegundos"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "un momento"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "un segundo"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d segundo"
 msgstr[1] "%d segundos"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "un minuto"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuto"
 msgstr[1] "%d minutos"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "una hora"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d hora"
 msgstr[1] "%d horas"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "un día"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d día"
 msgstr[1] "%d días"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "un mes"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mes"
 msgstr[1] "%d meses"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "un año"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 año y %d día"
 msgstr[1] "1 año y %d días"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 año y 1 mes"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 año y %d mes"
 msgstr[1] "1 año y %d meses"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d año"
 msgstr[1] "%d años"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "en %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "hace %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "ahora"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "hoy"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "mañana"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ayer"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s y %s"

--- a/src/humanize/locale/eu/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/eu/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-02 20:23+0100\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2023-01-02 20:35+0100\n"
 "Last-Translator: Mikel Olasagasti <mikel@olasagasti.info>\n"
 "Language-Team: Basque <translation-team-eu@googlegroups.com>\n"
@@ -230,131 +230,131 @@ msgstr "zortzi"
 msgid "nine"
 msgstr "bederatzi"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "mikrosegundo %d"
 msgstr[1] "%d mikrosegundo"
 
-#: src/humanize/time.py:160
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "milisegundo %d"
 msgstr[1] "%d milisegundo"
 
-#: src/humanize/time.py:163 src/humanize/time.py:258
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "une bat"
 
-#: src/humanize/time.py:166
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "segundo bat"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "segundo %d"
 msgstr[1] "%d segundo"
 
-#: src/humanize/time.py:172
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "minutu bat"
 
-#: src/humanize/time.py:176
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "minutu %d"
 msgstr[1] "%d minutu"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "ordu bat"
 
-#: src/humanize/time.py:183
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "ordu %d"
 msgstr[1] "%d ordu"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "egun bat"
 
-#: src/humanize/time.py:190 src/humanize/time.py:193
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "egun %d"
 msgstr[1] "%d egun"
 
-#: src/humanize/time.py:196
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "hilabete bat"
 
-#: src/humanize/time.py:198
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "hilabete %d"
 msgstr[1] "%d hilabete"
 
-#: src/humanize/time.py:202
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "urte bat"
 
-#: src/humanize/time.py:205 src/humanize/time.py:216
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "urte 1, egun %d"
 msgstr[1] "urte 1, %d egun"
 
-#: src/humanize/time.py:209
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "urte 1, hilabete 1"
 
-#: src/humanize/time.py:212
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "urte 1, hilabete %d"
 msgstr[1] "urte 1, %d hilabete"
 
-#: src/humanize/time.py:218
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "urte %d"
 msgstr[1] "%d urte"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "hemendik %s-(e)ra"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "orain dela %s"
 
-#: src/humanize/time.py:259
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "orain"
 
-#: src/humanize/time.py:283
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "gaur"
 
-#: src/humanize/time.py:286
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "bihar"
 
-#: src/humanize/time.py:289
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "atzo"
 

--- a/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fa_IR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2017-01-10 02:44+0330\n"
 "Last-Translator: Christian Klein <chris@5711.org>\n"
 "Language-Team: German\n"
@@ -19,347 +19,347 @@ msgstr ""
 "Generated-By: Christian Klein\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "صفرمین"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "اولین"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "دومین"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "سومین"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "چهارمین"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "پنجمین"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "ششمین"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "هفتمین"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "هشتمین"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "نهمین"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "صفرمین"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "اولین"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "دومین"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "سومین"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "چهارمین"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "پنجمین"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ششمین"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "هفتمین"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "هشتمین"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "نهمین"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "هزار"
 msgstr[1] "هزار"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "میلیون"
 msgstr[1] "میلیون"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "میلیارد"
 msgstr[1] "میلیارد"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "ترلیون"
 msgstr[1] "ترلیون"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "کوادریلیون"
 msgstr[1] "کوادریلیون"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "کوانتیلیون"
 msgstr[1] "کوانتیلیون"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "سکستیلیون"
 msgstr[1] "سکستیلیون"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "سپتیلیون"
 msgstr[1] "سپتیلیون"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "اوکتیلیون"
 msgstr[1] "اوکتیلیون"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "نونیلیون"
 msgstr[1] "نونیلیون"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "دسیلیون"
 msgstr[1] "دسیلیون"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "گوگول"
 msgstr[1] "گوگول"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "صفر"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "یک"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "دو"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "سه"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "چهار"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "پنج"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "شش"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "هفت"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "هشت"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "نه"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d میکرو‌ثانیه"
 msgstr[1] "%d میکرو‌ثانیه"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d میلی‌ثانیه"
 msgstr[1] "%d میلی‌ثانیه"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "یک لحظه"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "یک ثانیه"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d ثانیه"
 msgstr[1] "%d ثانیه"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "یک دقیقه"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d دقیقه"
 msgstr[1] "%d دقیقه"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "یک ساعت"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ساعت"
 msgstr[1] "%d ساعت"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "یک روز"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d روز"
 msgstr[1] "%d روز"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "یک ماه"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d ماه"
 msgstr[1] "%d ماه"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "یک سال"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "۱ سال و %d روز"
 msgstr[1] "۱ سال و %d روز"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "۱ سال و ۱ ماه"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "۱ سال و %d ماه"
 msgstr[1] "۱ سال و %d ماه"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d سال"
 msgstr[1] "%d سال"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s تا به اکنون"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s پیش"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "اکنون"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "امروز"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "فردا"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "دیروز"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s و %s"

--- a/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fi_FI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2017-03-02 11:26+0200\n"
 "Last-Translator: Ville Skyttä <ville.skytta@iki.fi>\n"
 "Language-Team: Finnish\n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.12\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tuhatta"
 msgstr[1] "tuhatta"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "miljoonaa"
 msgstr[1] "miljoonaa"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miljardia"
 msgstr[1] "miljardia"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "biljoonaa"
 msgstr[1] "biljoonaa"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "kvadriljoonaa"
 msgstr[1] "kvadriljoonaa"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "kvintiljoonaa"
 msgstr[1] "kvintiljoonaa"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sekstiljoonaa"
 msgstr[1] "sekstiljoonaa"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septiljoonaa"
 msgstr[1] "septiljoonaa"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "oktiljoonaa"
 msgstr[1] "oktiljoonaa"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "noniljoonaa"
 msgstr[1] "noniljoonaa"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "dekiljoonaa"
 msgstr[1] "dekiljoonaa"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nolla"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "yksi"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "kaksi"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "kolme"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "neljä"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "viisi"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "kuusi"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "seitsemän"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "kahdeksan"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "yhdeksän"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d mikrosekunti"
 msgstr[1] "%d mikrosekuntia"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d millisekunti"
 msgstr[1] "%d millisekuntia"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "hetki"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "sekunti"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d sekunti"
 msgstr[1] "%d sekuntia"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "minuutti"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuutti"
 msgstr[1] "%d minuuttia"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "tunti"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d tunti"
 msgstr[1] "%d tuntia"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "päivä"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d päivä"
 msgstr[1] "%d päivää"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "kuukausi"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d kuukausi"
 msgstr[1] "%d kuukautta"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "vuosi"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 vuosi, %d päivä"
 msgstr[1] "1 vuosi, %d päivää"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 vuosi, 1 kuukausi"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 vuosi, %d kuukausi"
 msgstr[1] "1 vuosi, %d kuukautta"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d vuosi"
 msgstr[1] "%d vuotta"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s tästä"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s sitten"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "nyt"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "tänään"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "huomenna"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "eilen"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s ja %s"

--- a/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/fr_FR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2013-06-22 08:52+0100\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: fr_FR <LL@li.org>\n"
@@ -19,357 +19,357 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "er"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "e"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "e"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ère"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "e"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "e"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "e"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 #, fuzzy
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s million"
 msgstr[1] "%(value)s million"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milliard"
 msgstr[1] "milliard"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 #, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s billion"
 msgstr[1] "%(value)s billion"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s billiard"
 msgstr[1] "%(value)s billiard"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s trillion"
 msgstr[1] "%(value)s trillion"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s trilliard"
 msgstr[1] "%(value)s trilliard"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s quatrillion"
 msgstr[1] "%(value)s quatrillion"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s quadrilliard"
 msgstr[1] "%(value)s quadrilliard"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s quintillion"
 msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s quintilliard"
 msgstr[1] "%(value)s quintilliard"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zéro"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "un"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "deux"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "trois"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "quatre"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinq"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "six"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sept"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "huit"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "neuf"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microseconde"
 msgstr[1] "%d microsecondes"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d milliseconde"
 msgstr[1] "%d millisecondes"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "un moment"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "une seconde"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d seconde"
 msgstr[1] "%d secondes"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "une minute"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minute"
 msgstr[1] "%d minutes"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "une heure"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d heure"
 msgstr[1] "%d heures"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "un jour"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d jour"
 msgstr[1] "%d jours"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "un mois"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mois"
 msgstr[1] "%d mois"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "un an"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "un an et %d jour"
 msgstr[1] "un an et %d jours"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "un an et un mois"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "un an et %d mois"
 msgstr[1] "un an et %d mois"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d an"
 msgstr[1] "%d ans"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "dans %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "il y a %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "maintenant"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "aujourd'hui"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "demain"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "hier"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s et %s"

--- a/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/id_ID/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2017-03-18 15:41+0700\n"
 "Last-Translator: adie.rebel@gmail.com\n"
 "Language-Team: Indonesian\n"
@@ -18,325 +18,325 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "juta"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliar"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "triliun"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "kuadriliun"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintillion"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextillion"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septillion"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octillion"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonillion"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decillion"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nol"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "satu"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dua"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tiga"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "empat"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "lima"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "enam"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "tujuh"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "delapan"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "sembilan"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d mikro detik"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d mili detik"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "beberapa saat"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "sedetik"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d detik"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "semenit"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d menit"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "sejam"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d jam"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "sehari"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d hari"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "sebulan"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d bulan"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "setahun"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 tahun, %d hari"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 tahun, 1 bulan"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 tahun, %d bulan"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d tahun"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s dari sekarang"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s yang lalu"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "sekarang"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "hari ini"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "besok"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "kemarin"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s dan %s"

--- a/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2018-10-27 22:52+0200\n"
 "Last-Translator: derfel <code@derfel.net>\n"
 "Language-Team: Italian\n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ª"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ª"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ª"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milioni"
 msgstr[1] "milioni"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliardi"
 msgstr[1] "miliardi"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilioni"
 msgstr[1] "bilioni"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biliardi"
 msgstr[1] "biliardi"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilioni"
 msgstr[1] "trilioni"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triliardi"
 msgstr[1] "triliardi"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quadrilioni"
 msgstr[1] "quadrilioni"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "quadriliardi"
 msgstr[1] "quadriliardi"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintilioni"
 msgstr[1] "quintilioni"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "quintiliardi"
 msgstr[1] "quintiliardi"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "uno"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "due"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tre"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "quattro"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinque"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sei"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sette"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "otto"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nove"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microsecondo"
 msgstr[1] "%d microsecondi"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d millisecondo"
 msgstr[1] "%d millisecondi"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "un momento"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "un secondo"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d secondo"
 msgstr[1] "%d secondi"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "un minuto"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuto"
 msgstr[1] "%d minuti"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "un'ora"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d ora"
 msgstr[1] "%d ore"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "un giorno"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d giorno"
 msgstr[1] "%d giorni"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "un mese"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mese"
 msgstr[1] "%d mesi"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "un anno"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "un anno e %d giorno"
 msgstr[1] "un anno e %d giorni"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "un anno ed un mese"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "un anno e %d mese"
 msgstr[1] "un anno e %d mesi"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d anno"
 msgstr[1] "%d anni"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "fra %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s fa"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "adesso"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "oggi"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "domani"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ieri"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ja_JP/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2018-01-22 10:48+0900\n"
 "Last-Translator: Kan Torii <oss@qoolloop.com>\n"
 "Language-Team: Japanese\n"
@@ -19,336 +19,336 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "番目"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "番目"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "番目"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "番目"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "番目"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "番目"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "番目"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "百万"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 #, fuzzy
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "十億"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "兆"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "千兆"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "百京"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "十垓"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "じょ"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "千じょ"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "百穣"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "十溝"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "溝無量大数"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "九"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] ""
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] ""
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 #, fuzzy
 msgid "a moment"
 msgstr "短時間"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "1秒"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d秒"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "1分"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d分"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "1時間"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d時間"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "1日"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d日"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "1ヶ月"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%dヶ月"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "1年"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1年 %d日"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1年 1ヶ月"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1年 %dヶ月"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d年"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s後"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s前"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 #, fuzzy
 msgid "now"
 msgstr "今"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "本日"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "明日"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "昨日"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2013-07-10 11:38+0900\n"
 "Last-Translator: @youngrok\n"
 "Language-Team: ko_KR <LL@li.org>\n"
@@ -19,376 +19,376 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 #, fuzzy
 msgctxt "0 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 #, fuzzy
 msgctxt "1 (male)"
 msgid "st"
 msgstr "번째"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 #, fuzzy
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "번째"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 #, fuzzy
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "번째"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 #, fuzzy
 msgctxt "4 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 #, fuzzy
 msgctxt "5 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 #, fuzzy
 msgctxt "6 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 #, fuzzy
 msgctxt "7 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 #, fuzzy
 msgctxt "8 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 #, fuzzy
 msgctxt "9 (male)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 #, fuzzy
 msgctxt "0 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 #, fuzzy
 msgctxt "1 (female)"
 msgid "st"
 msgstr "번째"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 #, fuzzy
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "번째"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 #, fuzzy
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "번째"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 #, fuzzy
 msgctxt "4 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 #, fuzzy
 msgctxt "5 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 #, fuzzy
 msgctxt "6 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 #, fuzzy
 msgctxt "7 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 #, fuzzy
 msgctxt "8 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 #, fuzzy
 msgctxt "9 (female)"
 msgid "th"
 msgstr "번째"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s million"
 msgstr[1] "%(value)s million"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milliard"
 msgstr[1] "milliard"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 #, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s billion"
 msgstr[1] "%(value)s billion"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s quadrillion"
 msgstr[1] "%(value)s quadrillion"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s quintillion"
 msgstr[1] "%(value)s quintillion"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s sextillion"
 msgstr[1] "%(value)s sextillion"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s septillion"
 msgstr[1] "%(value)s septillion"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s octillion"
 msgstr[1] "%(value)s octillion"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s nonillion"
 msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s décillion"
 msgstr[1] "%(value)s décillion"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "하나"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "둘"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "셋"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "넷"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "다섯"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "여섯"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "일곱"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "여덟"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "아홉"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d마이크로초"
 msgstr[1] "%d마이크로초"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d밀리초"
 msgstr[1] "%d밀리초"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "잠깐"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "1초"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d초"
 msgstr[1] "%d초"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "1분"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d분"
 msgstr[1] "%d분"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "1시간"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d시간"
 msgstr[1] "%d시간"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "하루"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d일"
 msgstr[1] "%d일"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "1개월"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d개월"
 msgstr[1] "%d개월"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "1년"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1년, %d일"
 msgstr[1] "1년, %d일"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1년, 1개월"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1년, %d개월"
 msgstr[1] "1년, %d개월"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d년"
 msgstr[1] "%d년"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s 후"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s 전"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "방금"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "오늘"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "내일"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "어제"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/nl_NL/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2015-03-25 21:08+0100\n"
 "Last-Translator: Martin van Wingerden\n"
 "Language-Team: nl_NL\n"
@@ -19,347 +19,347 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "ste"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "de"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "de"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ste"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "de"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "de"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "de"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "miljoen"
 msgstr[1] "miljoen"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miljard"
 msgstr[1] "miljard"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "biljoen"
 msgstr[1] "biljoen"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biljard"
 msgstr[1] "biljard"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "triljoen"
 msgstr[1] "triljoen"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triljard"
 msgstr[1] "triljard"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quadriljoen"
 msgstr[1] "quadriljoen"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "quadriljard"
 msgstr[1] "quadriljard"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintiljoen"
 msgstr[1] "quintiljoen"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "quintiljard"
 msgstr[1] "quintiljard"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nul"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "één"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "twee"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "drie"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "vier"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "vijf"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "zes"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "zeven"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "acht"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "negen"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microseconde"
 msgstr[1] "%d microseconden"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d milliseconde"
 msgstr[1] "%d milliseconden"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "een moment"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "een seconde"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d seconde"
 msgstr[1] "%d seconden"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "een minuut"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuut"
 msgstr[1] "%d minuten"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "een uur"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d uur"
 msgstr[1] "%d uur"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "een dag"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dag"
 msgstr[1] "%d dagen"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "een maand"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d maand"
 msgstr[1] "%d maanden"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "een jaar"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 jaar, %d dag"
 msgstr[1] "1 jaar, %d dagen"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 jaar, 1 maand"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 jaar, %d maand"
 msgstr[1] "1 jaar, %d maanden"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d jaar"
 msgstr[1] "%d jaar"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "over %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s geleden"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "nu"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "vandaag"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "morgen"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "gisteren"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s en %s"

--- a/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pl_PL/LC_MESSAGES/humanize.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2020-04-22 10:02+0200\n"
 "Last-Translator: Bartosz Bubak <bartosz.bubak gmail com>\n"
 "Language-Team: Polish\n"
@@ -20,231 +20,231 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tysiąc"
 msgstr[1] "tysiąc"
 msgstr[2] "tysięcy"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milion"
 msgstr[1] "miliony"
 msgstr[2] "milionów"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliard"
 msgstr[1] "miliardy"
 msgstr[2] "miliardów"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilion"
 msgstr[1] "biliony"
 msgstr[2] "bilionów"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biliard"
 msgstr[1] "biliardy"
 msgstr[2] "biliardów"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trylion"
 msgstr[1] "tryliony"
 msgstr[2] "trylionów"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "tryliard"
 msgstr[1] "tryliard"
 msgstr[2] "tryliard"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "kwadrylion"
 msgstr[1] "kwadryliony"
 msgstr[2] "kwadrylionów"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "kwadryliard"
 msgstr[1] "kwadryliardy"
 msgstr[2] "kwadryliardów"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "kwintylion"
 msgstr[1] "kwintyliony"
 msgstr[2] "kwintylionów"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "kwintyliard"
 msgstr[1] "kwintyliardy"
 msgstr[2] "kwintyliardów"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googole"
 msgstr[2] "googoli"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "jeden"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dwa"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "trzy"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "cztery"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "pięć"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sześć"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "siedem"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "osiem"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "dziewięć"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
@@ -252,7 +252,7 @@ msgstr[0] "%d mikrosekunda"
 msgstr[1] "%d mikrosekundy"
 msgstr[2] "%d mikrosekund"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
@@ -260,15 +260,15 @@ msgstr[0] "%d milisekunda"
 msgstr[1] "%d milisekundy"
 msgstr[2] "%d milisekund"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "chwila"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "sekunda"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
@@ -276,11 +276,11 @@ msgstr[0] "%d sekunda"
 msgstr[1] "%d sekundy"
 msgstr[2] "%d sekund"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "minuta"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -288,11 +288,11 @@ msgstr[0] "%d minuta"
 msgstr[1] "%d minuty"
 msgstr[2] "%d minut"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "godzina"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -300,11 +300,11 @@ msgstr[0] "%d godzina"
 msgstr[1] "%d godziny"
 msgstr[2] "%d godzin"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "dzień"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
@@ -312,11 +312,11 @@ msgstr[0] "%d dzień"
 msgstr[1] "%d dni"
 msgstr[2] "%d dni"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "miesiąc"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
@@ -324,11 +324,11 @@ msgstr[0] "%d miesiąc"
 msgstr[1] "%d miesiące"
 msgstr[2] "%d miesięcy"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "rok"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
@@ -336,11 +336,11 @@ msgstr[0] "1 rok, %d dzień"
 msgstr[1] "1 rok, %d dni"
 msgstr[2] "1 rok, %d dni"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 rok, 1 miesiąc"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
@@ -348,7 +348,7 @@ msgstr[0] "1 rok, %d miesiąc"
 msgstr[1] "1 rok, %d miesiące"
 msgstr[2] "1 rok, %d miesięcy"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
@@ -356,33 +356,33 @@ msgstr[0] "%d rok"
 msgstr[1] "%d lata"
 msgstr[2] "%d lat"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s od teraz"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s temu"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "teraz"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "dziś"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "jutro"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "wczoraj"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s i %s"

--- a/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_BR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2016-06-15 15:58-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 1.8.5\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ª"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ª"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ª"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milhão"
 msgstr[1] "milhão"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "bilhão"
 msgstr[1] "bilhão"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trilhão"
 msgstr[1] "trilhão"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "quatrilhão"
 msgstr[1] "quatrilhão"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "quintilhão"
 msgstr[1] "quintilhão"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sextilhão"
 msgstr[1] "sextilhão"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilhão"
 msgstr[1] "septilhão"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "octilhão"
 msgstr[1] "octilhão"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilhão"
 msgstr[1] "nonilhão"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "decilhão"
 msgstr[1] "decilhão"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "undecilhão"
 msgstr[1] "undecilhão"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nove"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microssegundo"
 msgstr[1] "%d microssegundos"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d milissegundo"
 msgstr[1] "%d milissegundos"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "um momento"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "um segundo"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d segundo"
 msgstr[1] "%d segundos"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "um minuto"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuto"
 msgstr[1] "%d minutos"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "uma hora"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d hora"
 msgstr[1] "%d horas"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "um dia"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dia"
 msgstr[1] "%d dias"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "um mês"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mês"
 msgstr[1] "%d meses"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "um ano"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 ano e %d dia"
 msgstr[1] "1 ano e %d dias"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 ano e 1 mês"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 ano e %d mês"
 msgstr[1] "1 ano e %d meses"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d ano"
 msgstr[1] "%d anos"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "em %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "há %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "agora"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "hoje"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ontem"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s e %s"

--- a/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/pt_PT/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2020-07-05 18:17+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,347 +18,347 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 2.3.1\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "º"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "º"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "º"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "º"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ª"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ª"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ª"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ª"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milhão"
 msgstr[1] "milhão"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milhar de milhão"
 msgstr[1] "milhar de milhão"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilião"
 msgstr[1] "bilião"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "mil biliões"
 msgstr[1] "mil biliões"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilião"
 msgstr[1] "trilião"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "mil triliões"
 msgstr[1] "mil triliões"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "quatrilião"
 msgstr[1] "quatrilião"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "mil quatriliões"
 msgstr[1] "mil quatriliões"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "quintilhão"
 msgstr[1] "quintilhão"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "mil quintilhões"
 msgstr[1] "mil quintilhões"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "sextilhão"
 msgstr[1] "sextilhão"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "zero"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "um"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dois"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "três"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "quatro"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "cinco"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "seis"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sete"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "oito"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nove"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d microssegundo"
 msgstr[1] "%d microssegundos"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d milissegundo"
 msgstr[1] "%d milissegundos"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "um momento"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "um segundo"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d segundo"
 msgstr[1] "%d segundos"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "um minuto"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minuto"
 msgstr[1] "%d minutos"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "uma hora"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d hora"
 msgstr[1] "%d horas"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "um dia"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dia"
 msgstr[1] "%d dias"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "um mês"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d mês"
 msgstr[1] "%d meses"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "um ano"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 ano e %d dia"
 msgstr[1] "1 ano e %d dias"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 ano e 1 mês"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 ano e %d mês"
 msgstr[1] "1 ano e %d meses"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d ano"
 msgstr[1] "%d anos"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "daqui a %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "há %s"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "agora"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "hoje"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ontem"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s e %s"

--- a/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ru_RU/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2014-03-24 20:32+0300\n"
 "Last-Translator: Sergey Prokhorov <me@seriyps.ru>\n"
 "Language-Team: ru_RU <LL@li.org>\n"
@@ -15,236 +15,236 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "ый"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "ой"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "ий"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ый"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ой"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ий"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ой"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ый"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "тысяча"
 msgstr[1] "тысячи"
 msgstr[2] "тысяч"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "миллион"
 msgstr[1] "миллиона"
 msgstr[2] "миллионов"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "миллиард"
 msgstr[1] "миллиарда"
 msgstr[2] "миллиардов"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "триллион"
 msgstr[1] "триллиона"
 msgstr[2] "триллионов"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "квадриллион"
 msgstr[1] "квадриллиона"
 msgstr[2] "квадриллионов"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "квинтиллион"
 msgstr[1] "квинтиллиона"
 msgstr[2] "квинтиллионов"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "сикстиллион"
 msgstr[1] "сикстиллиона"
 msgstr[2] "сикстиллионов"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "септиллион"
 msgstr[1] "септиллиона"
 msgstr[2] "септиллионов"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "октиллион"
 msgstr[1] "октиллиона"
 msgstr[2] "октиллионов"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "нониллион"
 msgstr[1] "нониллиона"
 msgstr[2] "нониллионов"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "децилион"
 msgstr[1] "децилиона"
 msgstr[2] "децилионов"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "гогол"
 msgstr[1] "гогола"
 msgstr[2] "гоголов"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "ноль"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "четыре"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "пять"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "шесть"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "семь"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "восемь"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "девять"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
@@ -252,7 +252,7 @@ msgstr[0] "%d микросекунда"
 msgstr[1] "%d микросекунды"
 msgstr[2] "%d микросекунд"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
@@ -260,15 +260,15 @@ msgstr[0] "%d миллисекунда"
 msgstr[1] "%d миллисекунды"
 msgstr[2] "%d миллисекунд"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "только что"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "секунду"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
@@ -276,11 +276,11 @@ msgstr[0] "%d секунда"
 msgstr[1] "%d секунды"
 msgstr[2] "%d секунд"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "минуту"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -288,11 +288,11 @@ msgstr[0] "%d минута"
 msgstr[1] "%d минуты"
 msgstr[2] "%d минут"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "час"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -300,11 +300,11 @@ msgstr[0] "%d час"
 msgstr[1] "%d часа"
 msgstr[2] "%d часов"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "день"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
@@ -312,11 +312,11 @@ msgstr[0] "%d день"
 msgstr[1] "%d дня"
 msgstr[2] "%d дней"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "месяц"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
@@ -324,11 +324,11 @@ msgstr[0] "%d месяц"
 msgstr[1] "%d месяца"
 msgstr[2] "%d месяцев"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "год"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
@@ -336,11 +336,11 @@ msgstr[0] "1 год, %d день"
 msgstr[1] "1 год, %d дня"
 msgstr[2] "1 год, %d дней"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 год, 1 месяц"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
@@ -348,7 +348,7 @@ msgstr[0] "1 год, %d месяц"
 msgstr[1] "1 год, %d месяца"
 msgstr[2] "1 год, %d месяцев"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
@@ -356,33 +356,33 @@ msgstr[0] "%d год"
 msgstr[1] "%d года"
 msgstr[2] "%d лет"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "через %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s назад"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "сейчас"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "сегодня"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "завтра"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "вчера"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s и %s"

--- a/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sk_SK/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2020-09-29 22:43+0300\n"
 "Last-Translator: Jose Riha <jose1711 gmail com>\n"
 "Language-Team: sk <LL@li.org>\n"
@@ -18,231 +18,231 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milióna/ov"
 msgstr[1] "milióna/ov"
 msgstr[2] "milióna/ov"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miliardy/árd"
 msgstr[1] "miliardy/árd"
 msgstr[2] "miliardy/árd"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilióna/ov"
 msgstr[1] "bilióna/ov"
 msgstr[2] "bilióna/ov"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biliardy/árd"
 msgstr[1] "biliardy/árd"
 msgstr[2] "biliardy/árd"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilióna/árd"
 msgstr[1] "trilióna/árd"
 msgstr[2] "trilióna/árd"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triliardy/árd"
 msgstr[1] "triliardy/árd"
 msgstr[2] "triliardy/árd"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "kvadrilióna/ov"
 msgstr[1] "kvadrilióna/ov"
 msgstr[2] "kvadrilióna/ov"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "kvadriliardy/árd"
 msgstr[1] "kvadriliardy/árd"
 msgstr[2] "kvadriliardy/árd"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "kvintilióna/ov"
 msgstr[1] "kvintilióna/ov"
 msgstr[2] "kvintilióna/ov"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "kvintiliardy/árd"
 msgstr[1] "kvintiliardy/árd"
 msgstr[2] "kvintiliardy/árd"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googola/ov"
 msgstr[1] "googola/ov"
 msgstr[2] "googola/ov"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nula"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "jedna"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dve"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tri"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "štyri"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "päť"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "šesť"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sedem"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "osem"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "deväť"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
@@ -250,7 +250,7 @@ msgstr[0] "%d mikrosekundu"
 msgstr[1] "%d mikrosekundy"
 msgstr[2] "%d mikrosekúnd"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
@@ -258,15 +258,15 @@ msgstr[0] "%d milisekundu"
 msgstr[1] "%d milisekundy"
 msgstr[2] "%d milisekúnd"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "chvíľku"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "sekundu"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
@@ -274,11 +274,11 @@ msgstr[0] "%d sekundu"
 msgstr[1] "%d sekundy"
 msgstr[2] "%d sekúnd"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "minútu"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -286,11 +286,11 @@ msgstr[0] "%d minútu"
 msgstr[1] "%d minúty"
 msgstr[2] "%d minút"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "hodinu"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -298,11 +298,11 @@ msgstr[0] "%d hodina"
 msgstr[1] "%d hodiny"
 msgstr[2] "%d hodín"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "deň"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
@@ -310,11 +310,11 @@ msgstr[0] "%d deň"
 msgstr[1] "%d dni"
 msgstr[2] "%d dní"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "mesiac"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
@@ -322,11 +322,11 @@ msgstr[0] "%d mesiac"
 msgstr[1] "%d mesiace"
 msgstr[2] "%d mesiacov"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "rok"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
@@ -334,11 +334,11 @@ msgstr[0] "1 rok, %d deň"
 msgstr[1] "1 rok, %d dni"
 msgstr[2] "1 rok, %d dní"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 rok, 1 mesiac"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
@@ -346,7 +346,7 @@ msgstr[0] "1 rok, %d mesiac"
 msgstr[1] "1 rok, %d mesiace"
 msgstr[2] "1 rok, %d mesiacov"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
@@ -354,33 +354,33 @@ msgstr[0] "%d rok"
 msgstr[1] "%d roky"
 msgstr[2] "%d rokov"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "o %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s naspäť"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "teraz"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "dnes"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "zajtra"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "včera"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/sl_SI/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sl_SI/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-11 22:52+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2021-06-11 23:39+0200\n"
 "Last-Translator: dkrat7 <dkrat7 @github.com>\n"
 "Language-Team: Slovenian\n"
@@ -15,111 +15,111 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:67
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:80
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tisoč"
@@ -127,7 +127,7 @@ msgstr[1] "tisoč"
 msgstr[2] "tisoč"
 msgstr[3] "tisoč"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milijon"
@@ -135,7 +135,7 @@ msgstr[1] "milijona"
 msgstr[2] "milijoni"
 msgstr[3] "milijonov"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milijarda"
@@ -143,7 +143,7 @@ msgstr[1] "milijardi"
 msgstr[2] "milijarde"
 msgstr[3] "milijard"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "bilijon"
@@ -151,7 +151,7 @@ msgstr[1] "bilijona"
 msgstr[2] "bilijoni"
 msgstr[3] "bilijonov"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "bilijarda"
@@ -159,7 +159,7 @@ msgstr[1] "bilijardi"
 msgstr[2] "bilijarde"
 msgstr[3] "bilijard"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "trilijon"
@@ -167,7 +167,7 @@ msgstr[1] "trilijona"
 msgstr[2] "trilijoni"
 msgstr[3] "trilijonov"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "trilijarda"
@@ -175,7 +175,7 @@ msgstr[1] "trilijardi"
 msgstr[2] "trilijarde"
 msgstr[3] "trilijard"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "kvadrilijon"
@@ -183,7 +183,7 @@ msgstr[1] "kvadrilijona"
 msgstr[2] "kvadrilijoni"
 msgstr[3] "kvadrilijonov"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "kvadrilijarda"
@@ -191,7 +191,7 @@ msgstr[1] "kvadrilijardi"
 msgstr[2] "kvadrilijarde"
 msgstr[3] "kvadrilijard"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "kvintilijon"
@@ -199,7 +199,7 @@ msgstr[1] "kvintilijona"
 msgstr[2] "kvintilijoni"
 msgstr[3] "kvintilijonov"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "kvintilijarda"
@@ -207,7 +207,7 @@ msgstr[1] "kvintilijardi"
 msgstr[2] "kvintilijarde"
 msgstr[3] "kvintilijard"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "gugol"
@@ -215,47 +215,47 @@ msgstr[1] "gugola"
 msgstr[2] "gugoli"
 msgstr[3] "gugolov"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "nič"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "ena"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "dve"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tri"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "štiri"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "pet"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "šest"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sedem"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "osem"
 
-#: src/humanize/number.py:256
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "devet"
 
-#: src/humanize/time.py:138
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
@@ -264,7 +264,7 @@ msgstr[1] "%d mikrosekundi"
 msgstr[2] "%d mikrosekunde"
 msgstr[3] "%d mikrosekund"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
@@ -273,15 +273,15 @@ msgstr[1] "%d milisekundi"
 msgstr[2] "%d milisekunde"
 msgstr[3] "%d milisekund"
 
-#: src/humanize/time.py:150 src/humanize/time.py:231
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "trenutek"
 
-#: src/humanize/time.py:152
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "sekunda"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
@@ -290,11 +290,11 @@ msgstr[1] "%d sekundi"
 msgstr[2] "%d sekunde"
 msgstr[3] "%d sekund"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "minuta"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -303,11 +303,11 @@ msgstr[1] "%d minuti"
 msgstr[2] "%d minute"
 msgstr[3] "%d minut"
 
-#: src/humanize/time.py:161
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "ura"
 
-#: src/humanize/time.py:164
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -316,11 +316,11 @@ msgstr[1] "%d uri"
 msgstr[2] "%d ure"
 msgstr[3] "%d ur"
 
-#: src/humanize/time.py:167
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "dan"
 
-#: src/humanize/time.py:169 src/humanize/time.py:172
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
@@ -329,11 +329,11 @@ msgstr[1] "%d dneva"
 msgstr[2] "%d dnevi"
 msgstr[3] "%d dni"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "mesec"
 
-#: src/humanize/time.py:176
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
@@ -342,11 +342,11 @@ msgstr[1] "%d meseca"
 msgstr[2] "%d meseci"
 msgstr[3] "%d mesecev"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "leto"
 
-#: src/humanize/time.py:181 src/humanize/time.py:190
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
@@ -355,11 +355,11 @@ msgstr[1] "1 leto, %d dneva"
 msgstr[2] "1 leto, %d dnevi"
 msgstr[3] "1 leto, %d dni"
 
-#: src/humanize/time.py:184
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 leto, 1 mesec"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
@@ -368,7 +368,7 @@ msgstr[1] "1 leto, %d meseca"
 msgstr[2] "1 leto, %d meseci"
 msgstr[3] "1 leto, %d mesecev"
 
-#: src/humanize/time.py:192
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
@@ -377,33 +377,33 @@ msgstr[1] "%d leti"
 msgstr[2] "%d leta"
 msgstr[3] "%d let"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s od zdaj"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s nazaj"
 
-#: src/humanize/time.py:232
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "zdaj"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "danes"
 
-#: src/humanize/time.py:257
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "jutri"
 
-#: src/humanize/time.py:259
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "včeraj"
 
-#: src/humanize/time.py:545
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s in %s"

--- a/src/humanize/locale/sv_SE/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/sv_SE/LC_MESSAGES/humanize.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
-"Report-Msgid-Bugs-To: https://github.com/python-humanize/humanize/issues\n"
-"POT-Creation-Date: 2021-07-05 09:49+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2021-07-05 10:30+0200\n"
 "Last-Translator: Kess Vargavind <vargavind@gmail.com>\n"
 "Language-Team: Swedish\n"
@@ -17,347 +17,347 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr ":a"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr ":a"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr ":e"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:67
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr ":a"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr ":a"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr ":e"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:80
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr ":e"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "tusen"
 msgstr[1] "tusen"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "miljon"
 msgstr[1] "miljoner"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "miljard"
 msgstr[1] "miljarder"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "biljon"
 msgstr[1] "biljoner"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "biljard"
 msgstr[1] "biljarder"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "triljon"
 msgstr[1] "triljoner"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "triljard"
 msgstr[1] "triljarder"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "kvadriljon"
 msgstr[1] "kvadriljoner"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "kvadriljard"
 msgstr[1] "kvadriljarder"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "kvintiljon"
 msgstr[1] "kvintiljoner"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "kvintiljard"
 msgstr[1] "kvintiljarder"
 
-#: src/humanize/number.py:152
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "noll"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "ett"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "två"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "tre"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "fyra"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "fem"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sex"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "sju"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "åtta"
 
-#: src/humanize/number.py:256
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "nio"
 
-#: src/humanize/time.py:138
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d mikrosekund"
 msgstr[1] "%d mikrosekunder"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d millsekund"
 msgstr[1] "%d millsekunder"
 
-#: src/humanize/time.py:150 src/humanize/time.py:231
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "en liten stund"
 
-#: src/humanize/time.py:152
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "en sekund"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d sekund"
 msgstr[1] "%d sekunder"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "en minut"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d minut"
 msgstr[1] "%d minuter"
 
-#: src/humanize/time.py:161
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "en timme"
 
-#: src/humanize/time.py:164
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d timme"
 msgstr[1] "%d timmar"
 
-#: src/humanize/time.py:167
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "en dag"
 
-#: src/humanize/time.py:169 src/humanize/time.py:172
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d dag"
 msgstr[1] "%d dagar"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "en månad"
 
-#: src/humanize/time.py:176
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d månad"
 msgstr[1] "%d månader"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "ett år"
 
-#: src/humanize/time.py:181 src/humanize/time.py:190
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 år, %d dag"
 msgstr[1] "1 år, %d dagar"
 
-#: src/humanize/time.py:184
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 år, 1 månad"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 år, %d månad"
 msgstr[1] "1 år, %d månader"
 
-#: src/humanize/time.py:192
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d år"
 msgstr[1] "%d år"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s från nu"
 
-#: src/humanize/time.py:228
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s sedan"
 
-#: src/humanize/time.py:232
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "nu"
 
-#: src/humanize/time.py:255
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "idag"
 
-#: src/humanize/time.py:257
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "imorgon"
 
-#: src/humanize/time.py:259
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "igår"
 
-#: src/humanize/time.py:545
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s och %s"

--- a/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/tr_TR/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2017-02-23 20:00+0300\n"
 "Last-Translator: Emre Çintay <emre@cintay.com>\n"
 "Language-Team: Turkish\n"
@@ -19,347 +19,347 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Generated-By: Emre Çintay\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "milyon"
 msgstr[1] "milyon"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "milyar"
 msgstr[1] "milyar"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "trilyon"
 msgstr[1] "trilyon"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "katrilyon"
 msgstr[1] "katrilyon"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "kentilyon"
 msgstr[1] "kentilyon"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "sekstilyon"
 msgstr[1] "sekstilyon"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "septilyon"
 msgstr[1] "septilyon"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "oktilyon"
 msgstr[1] "oktilyon"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "nonilyon"
 msgstr[1] "nonilyon"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "desilyon"
 msgstr[1] "desilyon"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "googol"
 msgstr[1] "googol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "bir"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "iki"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "üç"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "dört"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "beş"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "altı"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "yedi"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "sekiz"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "dokuz"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "biraz"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "bir saniye"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d saniye"
 msgstr[1] "%d saniye"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "bir dakika"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d dakika"
 msgstr[1] "%d dakika"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "bir saat"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d saat"
 msgstr[1] "%d saat"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "bir gün"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d gün"
 msgstr[1] "%d gün"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "bir ay"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d ay"
 msgstr[1] "%d ay"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "bir yıl"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 yıl, %d gün"
 msgstr[1] "1 yıl, %d gün"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 yıl, 1 ay"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 yıl, %d ay"
 msgstr[1] "1 yıl, %d ay"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d yıl"
 msgstr[1] "%d yıl"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "şu andan itibaren %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s önce"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "şimdi"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "bugün"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "yarın"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "dün"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/uk_UA/LC_MESSAGES/humanize.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: TL\n"
 "Language-Team: uk_UA\n"
@@ -10,236 +10,236 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "Generated-By:\n"
 "X-Generator: \n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "ий"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "ий"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "ій"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "ий"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "ий"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "ій"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "ий"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "тисяча"
 msgstr[1] "тисячі"
 msgstr[2] "тисяч"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "мільйон"
 msgstr[1] "мільйона"
 msgstr[2] "мільйонів"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "мільярд"
 msgstr[1] "мільярда"
 msgstr[2] "мільярдів"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "трильйон"
 msgstr[1] "трильйона"
 msgstr[2] "трильйонів"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "квадрильйон"
 msgstr[1] "квадрильйона"
 msgstr[2] "квадрильйонів"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "квинтиліон"
 msgstr[1] "квинтиліона"
 msgstr[2] "квинтиліонів"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "сикстильйон"
 msgstr[1] "сикстильйона"
 msgstr[2] "сикстильйонів"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "септильйон"
 msgstr[1] "септильйона"
 msgstr[2] "септильйонів"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "октильйон"
 msgstr[1] "октильйона"
 msgstr[2] "октильйонів"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "нонильйон"
 msgstr[1] "нонильйона"
 msgstr[2] "нонильйонів"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "децильйон"
 msgstr[1] "децильйона"
 msgstr[2] "децильйонів"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "гугол"
 msgstr[1] "гугла"
 msgstr[2] "гуглів"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "нуль"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "один"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "два"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "три"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "чотири"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "п'ять"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "шість"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "сім"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "вісім"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "дев'ять"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, fuzzy, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
@@ -247,7 +247,7 @@ msgstr[0] "%d мікросекунда"
 msgstr[1] "%d мікросекунди"
 msgstr[2] "%d мікросекунд"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, fuzzy, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
@@ -255,15 +255,15 @@ msgstr[0] "%d мілісекунда"
 msgstr[1] "%d мілісекунди"
 msgstr[2] "%d мілісекунд"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "у цей момент"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "секунда"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
@@ -271,11 +271,11 @@ msgstr[0] "%d секунда"
 msgstr[1] "%d секунди"
 msgstr[2] "%d секунд"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "хвилина"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
@@ -283,11 +283,11 @@ msgstr[0] "%d хвилина"
 msgstr[1] "%d хвилини"
 msgstr[2] "%d хвилин"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "година"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
@@ -295,11 +295,11 @@ msgstr[0] "%d година"
 msgstr[1] "%d години"
 msgstr[2] "%d годин"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "день"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
@@ -307,11 +307,11 @@ msgstr[0] "%d день"
 msgstr[1] "%d дня"
 msgstr[2] "%d днів"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "місяць"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
@@ -319,11 +319,11 @@ msgstr[0] "%d місяць"
 msgstr[1] "%d місяця"
 msgstr[2] "%d місяців"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "рік"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
@@ -331,11 +331,11 @@ msgstr[0] "1 рік, %d день"
 msgstr[1] "1 рік, %d дня"
 msgstr[2] "1 рік, %d днів"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 рік, 1 місяць"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
@@ -343,7 +343,7 @@ msgstr[0] "1 рік, %d місяць"
 msgstr[1] "1 рік, %d місяця"
 msgstr[2] "1 рік, %d місяців"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
@@ -351,33 +351,33 @@ msgstr[0] "%d рік"
 msgstr[1] "%d роки"
 msgstr[2] "%d років"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "через %s"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s назад"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "зараз"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "сьогодні"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "завтра"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "вчора"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s й %s"

--- a/src/humanize/locale/vi_VN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/vi_VN/LC_MESSAGES/humanize.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2017-05-30 11:51+0700\n"
 "Last-Translator: Olivier Cortès <oc@1flow.io>\n"
 "Language-Team: vi_VI <sapd@vccloud.vn>\n"
@@ -19,354 +19,354 @@ msgstr ""
 "Generated-By: Babel 0.9.6\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "."
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "."
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "."
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "."
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "nghìn"
 msgstr[1] "nghìn"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "%(value)s triệu"
 msgstr[1] "%(value)s triệu"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "tỷ"
 msgstr[1] "tỷ"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "%(value)s nghìn tỷ"
 msgstr[1] "%(value)s nghìn tỷ"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "%(value)s triệu tỷ"
 msgstr[1] "%(value)s triệu tỷ"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "%(value)s tỷ tỷ"
 msgstr[1] "%(value)s tỷ tỷ"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "%(value)s sextillion"
 msgstr[1] "%(value)s sextillion"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "%(value)s septillion"
 msgstr[1] "%(value)s septillion"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "%(value)s octillion"
 msgstr[1] "%(value)s octillion"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "%(value)s nonillion"
 msgstr[1] "%(value)s nonillion"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "%(value)s décillion"
 msgstr[1] "%(value)s décillion"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "%(value)s gogol"
 msgstr[1] "%(value)s gogol"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "không"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "một"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "hai"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "ba"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "bốn"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "năm"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "sáu"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "bảy"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "tám"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "chín"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d micro giây"
 msgstr[1] "%d micro giây"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d mili giây"
 msgstr[1] "%d mili giây"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "ngay lúc này"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "một giây"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d giây"
 msgstr[1] "%d giây"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "một phút"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d phút"
 msgstr[1] "%d phút"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "một giờ"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d giờ"
 msgstr[1] "%d giờ"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "một ngày"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d ngày"
 msgstr[1] "%d ngày"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "một tháng"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d tháng"
 msgstr[1] "%d tháng"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "một năm"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "1 năm %d ngày"
 msgstr[1] "1 năm %d ngày"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 năm 1 tháng"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 năm %d tháng"
 msgstr[1] "un an et %d mois"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d năm"
 msgstr[1] "%d năm"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s ngày tới"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s trước"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "ngay bây giờ"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "hôm nay"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "ngày mai"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "ngày hôm qua"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s và %s"

--- a/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2016-11-14 23:02+0000\n"
 "Last-Translator: Liwen SUN <sunliwen@gmail.com>\n"
 "Language-Team: Chinese (simplified)\n"
@@ -18,347 +18,347 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "第"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "第"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "第"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "第"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "第"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "第"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "百万"
 msgstr[1] "百万"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "十亿"
 msgstr[1] "十亿"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "兆"
 msgstr[1] "兆"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "万亿"
 msgstr[1] "万亿"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "百京"
 msgstr[1] "百京"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "十垓"
 msgstr[1] "十垓"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "秭"
 msgstr[1] "秭"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "千秭"
 msgstr[1] "千秭"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "百穰"
 msgstr[1] "百穰"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "十沟"
 msgstr[1] "十沟"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "古高尔"
 msgstr[1] "古高尔"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr ""
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "九"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "一会儿"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "1秒"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d秒"
 msgstr[1] "%d秒"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "1分"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d分"
 msgstr[1] "%d分"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "1小时"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d小时"
 msgstr[1] "%d小时"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "1天"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d天"
 msgstr[1] "%d天"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "1月"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d月"
 msgstr[1] "%d月"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "1年"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "%d年"
 msgstr[1] "%d年"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1年又1月"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1年又%d月"
 msgstr[1] "1年又%d月"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d年"
 msgstr[1] "%d年"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s之后"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s之前"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "现在"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "今天"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "明天"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "昨天"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr ""

--- a/src/humanize/locale/zh_HK/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/zh_HK/LC_MESSAGES/humanize.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-04 23:15+0200\n"
+"POT-Creation-Date: 2023-01-08 19:22+0200\n"
 "PO-Revision-Date: 2016-11-14 23:02+0000\n"
 "Last-Translator: Edward Ho <edward@edward.is>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -19,347 +19,347 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/humanize/number.py:57
+#: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:58
+#: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
 msgstr "第"
 
-#: src/humanize/number.py:59
+#: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
 msgstr "第"
 
-#: src/humanize/number.py:60
+#: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
 msgstr "第"
 
-#: src/humanize/number.py:61
+#: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:62
+#: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:63
+#: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:64
+#: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:65
+#: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:66
+#: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:70
+#: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:71
+#: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
 msgstr "第"
 
-#: src/humanize/number.py:72
+#: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
 msgstr "第"
 
-#: src/humanize/number.py:73
+#: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
 msgstr "第"
 
-#: src/humanize/number.py:74
+#: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:75
+#: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:76
+#: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:77
+#: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:78
+#: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:79
+#: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
 msgstr "第"
 
-#: src/humanize/number.py:140
+#: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
 msgstr[0] "千"
 msgstr[1] "千"
 
-#: src/humanize/number.py:141
+#: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
 msgstr[0] "百萬"
 msgstr[1] "百萬"
 
-#: src/humanize/number.py:142
+#: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
 msgstr[0] "十億"
 msgstr[1] "十億"
 
-#: src/humanize/number.py:143
+#: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
 msgstr[0] "兆"
 msgstr[1] "兆"
 
-#: src/humanize/number.py:144
+#: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
 msgstr[0] "萬億"
 msgstr[1] "萬億"
 
-#: src/humanize/number.py:145
+#: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
 msgstr[0] "百京"
 msgstr[1] "百京"
 
-#: src/humanize/number.py:146
+#: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
 msgstr[0] "十垓"
 msgstr[1] "十垓"
 
-#: src/humanize/number.py:147
+#: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
 msgstr[0] "秭"
 msgstr[1] "秭"
 
-#: src/humanize/number.py:148
+#: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
 msgstr[0] "千秭"
 msgstr[1] "千秭"
 
-#: src/humanize/number.py:149
+#: src/humanize/number.py:187
 msgid "nonillion"
 msgid_plural "nonillion"
 msgstr[0] "百穰"
 msgstr[1] "百穰"
 
-#: src/humanize/number.py:150
+#: src/humanize/number.py:188
 msgid "decillion"
 msgid_plural "decillion"
 msgstr[0] "十溝"
 msgstr[1] "十溝"
 
-#: src/humanize/number.py:151
+#: src/humanize/number.py:189
 msgid "googol"
 msgid_plural "googol"
 msgstr[0] "古高爾"
 msgstr[1] "古高爾"
 
-#: src/humanize/number.py:246
+#: src/humanize/number.py:301
 msgid "zero"
 msgstr "零"
 
-#: src/humanize/number.py:247
+#: src/humanize/number.py:302
 msgid "one"
 msgstr "一"
 
-#: src/humanize/number.py:248
+#: src/humanize/number.py:303
 msgid "two"
 msgstr "二"
 
-#: src/humanize/number.py:249
+#: src/humanize/number.py:304
 msgid "three"
 msgstr "三"
 
-#: src/humanize/number.py:250
+#: src/humanize/number.py:305
 msgid "four"
 msgstr "四"
 
-#: src/humanize/number.py:251
+#: src/humanize/number.py:306
 msgid "five"
 msgstr "五"
 
-#: src/humanize/number.py:252
+#: src/humanize/number.py:307
 msgid "six"
 msgstr "六"
 
-#: src/humanize/number.py:253
+#: src/humanize/number.py:308
 msgid "seven"
 msgstr "七"
 
-#: src/humanize/number.py:254
+#: src/humanize/number.py:309
 msgid "eight"
 msgstr "八"
 
-#: src/humanize/number.py:255
+#: src/humanize/number.py:310
 msgid "nine"
 msgstr "九"
 
-#: src/humanize/time.py:133
+#: src/humanize/time.py:152
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
 msgstr[0] "%d 微秒"
 msgstr[1] "%d 微秒"
 
-#: src/humanize/time.py:142
+#: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
 msgstr[0] "%d 毫秒"
 msgstr[1] "%d 毫秒"
 
-#: src/humanize/time.py:145 src/humanize/time.py:220
+#: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
 msgstr "一會"
 
-#: src/humanize/time.py:147
+#: src/humanize/time.py:167
 msgid "a second"
 msgstr "1 秒"
 
-#: src/humanize/time.py:149
+#: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
 msgstr[0] "%d 秒"
 msgstr[1] "%d 秒"
 
-#: src/humanize/time.py:151
+#: src/humanize/time.py:173
 msgid "a minute"
 msgstr "1 分鐘"
 
-#: src/humanize/time.py:154
+#: src/humanize/time.py:177
 #, python-format
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] "%d 分鐘"
 msgstr[1] "%d 分鐘"
 
-#: src/humanize/time.py:156
+#: src/humanize/time.py:180
 msgid "an hour"
 msgstr "1 小時"
 
-#: src/humanize/time.py:159
+#: src/humanize/time.py:184
 #, python-format
 msgid "%d hour"
 msgid_plural "%d hours"
 msgstr[0] "%d 小時"
 msgstr[1] "%d 小時"
 
-#: src/humanize/time.py:162
+#: src/humanize/time.py:188
 msgid "a day"
 msgstr "1 天"
 
-#: src/humanize/time.py:164 src/humanize/time.py:167
+#: src/humanize/time.py:191 src/humanize/time.py:194
 #, python-format
 msgid "%d day"
 msgid_plural "%d days"
 msgstr[0] "%d 天"
 msgstr[1] "%d 天"
 
-#: src/humanize/time.py:169
+#: src/humanize/time.py:197
 msgid "a month"
 msgstr "1 月"
 
-#: src/humanize/time.py:171
+#: src/humanize/time.py:199
 #, python-format
 msgid "%d month"
 msgid_plural "%d months"
 msgstr[0] "%d 月"
 msgstr[1] "%d 月"
 
-#: src/humanize/time.py:174
+#: src/humanize/time.py:203
 msgid "a year"
 msgstr "1 年"
 
-#: src/humanize/time.py:176 src/humanize/time.py:185
+#: src/humanize/time.py:206 src/humanize/time.py:217
 #, python-format
 msgid "1 year, %d day"
 msgid_plural "1 year, %d days"
 msgstr[0] "%d 年"
 msgstr[1] "%d 年"
 
-#: src/humanize/time.py:179
+#: src/humanize/time.py:210
 msgid "1 year, 1 month"
 msgstr "1 年又 1 個月"
 
-#: src/humanize/time.py:182
+#: src/humanize/time.py:213
 #, python-format
 msgid "1 year, %d month"
 msgid_plural "1 year, %d months"
 msgstr[0] "1 年又 %d 個月"
 msgstr[1] "1 年又 %d 個月"
 
-#: src/humanize/time.py:187
+#: src/humanize/time.py:219
 #, python-format
 msgid "%d year"
 msgid_plural "%d years"
 msgstr[0] "%d年"
 msgstr[1] "%d年"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
 msgstr "%s 之後"
 
-#: src/humanize/time.py:217
+#: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
 msgstr "%s 之前"
 
-#: src/humanize/time.py:221
+#: src/humanize/time.py:260
 msgid "now"
 msgstr "現在"
 
-#: src/humanize/time.py:244
+#: src/humanize/time.py:284
 msgid "today"
 msgstr "今天"
 
-#: src/humanize/time.py:246
+#: src/humanize/time.py:287
 msgid "tomorrow"
 msgstr "明天"
 
-#: src/humanize/time.py:248
+#: src/humanize/time.py:290
 msgid "yesterday"
 msgstr "昨天"
 
-#: src/humanize/time.py:534
+#: src/humanize/time.py:600
 #, python-format
 msgid "%s and %s"
 msgstr "%s 與 %s"


### PR DESCRIPTION
Running current proposed command:

```
xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -l python src/humanize/*.py 
$ pocount humanize.pot |grep Total
Total:           45                60                      0
```

Adding missing `_NS` and `_ngettext` keys:
```
xgettext --from-code=UTF-8 -o humanize.pot -k'_' -k'N_' -k'P_:1c,2' -k'NS_:1,2' -k'_ngettext:1,2' -l python src/humanize/*.py
$ pocount humanize.pot |grep Total
Total:           67               132                      0
```

Add the following missing strings:

+msgid "thousand"
+msgid_plural "thousand"
+msgid "million"
+msgid_plural "million"
+msgid "billion"
+msgid_plural "billion"
+msgid "trillion"
+msgid_plural "trillion"
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgid "quintillion"
+msgid_plural "quintillion"
+msgid "sextillion"
+msgid_plural "sextillion"
+msgid "septillion"
+msgid_plural "septillion"
+msgid "octillion"
+msgid_plural "octillion"
+msgid "nonillion"
+msgid_plural "nonillion"
+msgid "decillion"
+msgid_plural "decillion"
+msgid "googol"
+msgid_plural "googol"
+msgid "%d microsecond"
+msgid_plural "%d microseconds"
+msgid "%d millisecond"
+msgid_plural "%d milliseconds"
+msgid "%d second"
+msgid_plural "%d seconds"
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgid "%d hour"
+msgid_plural "%d hours"
+msgid "%d day"
+msgid_plural "%d days"
+msgid "%d month"
+msgid_plural "%d months"
+msgid "1 year, %d day"
+msgid_plural "1 year, %d days"
+msgid "1 year, %d month"
+msgid_plural "1 year, %d months"
+msgid "%d year"
+msgid_plural "%d years"
