### PR TITLE
Add Italian translation for "%s and %s"

### DIFF
--- a/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/it_IT/LC_MESSAGES/humanize.po
@@ -361,4 +361,4 @@ msgstr "ieri"
 #: src/humanize/time.py:534
 #, python-format
 msgid "%s and %s"
-msgstr ""
+msgstr "%s e %s"


### PR DESCRIPTION
Fixes #94.

Changes proposed in this pull request:

* Should be "%s e %s"
