### PR TITLE
Update Bengali translation

### DIFF
--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -341,7 +341,7 @@ msgstr "আজ থেকে %s সময় পরে"
 #: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
-msgstr "%s দিন আগে"
+msgstr "%s সময় আগে"
 
 #: src/humanize/time.py:260
 msgid "now"

--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the humanize package.
 # Wasi Master <arianmollik323@gmail.com>, 2021.
-#
+# Zarif Ahnaf <zarifahnaf@outlook.com>, 2023
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
@@ -120,27 +120,27 @@ msgstr ""
 #: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d হাজার"
+msgstr[1] "%d হাজার"
 
 #: src/humanize/number.py:179
 #, fuzzy
 msgid "million"
 msgid_plural "million"
-msgstr[0] "%d মিলিসেকন্ড"
-msgstr[1] "%d মিলিসেকন্ড"
+msgstr[0] "%d মিলিয়ন"
+msgstr[1] "%d মিলিয়ন"
 
 #: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d বিলিয়ন"
+msgstr[1] "%d বিলিয়ন"
 
 #: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d ট্রিলিয়ন"
+msgstr[1] "%d ট্রিলিয়ন"
 
 #: src/humanize/number.py:182
 msgid "quadrillion"
@@ -182,8 +182,8 @@ msgstr[1] ""
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
-msgstr[0] "%d মিলিসেকন্ড"
-msgstr[1] "%d মিলিসেকন্ড"
+msgstr[0] ""
+msgstr[1] ""
 
 #: src/humanize/number.py:189
 msgid "googol"
@@ -213,7 +213,7 @@ msgstr "চার"
 
 #: src/humanize/number.py:306
 msgid "five"
-msgstr "পাচ"
+msgstr "পাঁচ"
 
 #: src/humanize/number.py:307
 msgid "six"
@@ -235,15 +235,15 @@ msgstr "নয়"
 #, python-format
 msgid "%d microsecond"
 msgid_plural "%d microseconds"
-msgstr[0] "%d মাইক্রোসেকন্ড"
-msgstr[1] "%d মাইক্রোসেকন্ড"
+msgstr[0] "%d মাইক্রোসেকেন্ড"
+msgstr[1] "%d মাইক্রোসেকেন্ড"
 
 #: src/humanize/time.py:161
 #, python-format
 msgid "%d millisecond"
 msgid_plural "%d milliseconds"
-msgstr[0] "%d মিলিসেকন্ড"
-msgstr[1] "%d মিলিসেকন্ড"
+msgstr[0] "%d মিলিসেকেন্ড"
+msgstr[1] "%d মিলিসেকেন্ড"
 
 #: src/humanize/time.py:164 src/humanize/time.py:259
 msgid "a moment"
@@ -251,14 +251,14 @@ msgstr "এক মুহুর্ত"
 
 #: src/humanize/time.py:167
 msgid "a second"
-msgstr "এক সেকন্ড"
+msgstr "এক সেকেন্ড"
 
 #: src/humanize/time.py:170
 #, python-format
 msgid "%d second"
 msgid_plural "%d seconds"
-msgstr[0] "%d সেকন্ড"
-msgstr[1] "%d সেকন্ড"
+msgstr[0] "%d সেকেন্ড"
+msgstr[1] "%d সেকেন্ড"
 
 #: src/humanize/time.py:173
 msgid "a minute"
@@ -336,12 +336,12 @@ msgstr[1] "%d বছর"
 #: src/humanize/time.py:256
 #, python-format
 msgid "%s from now"
-msgstr "আজ থেকে %s পরে"
+msgstr "আজ থেকে %s সময় পরে"
 
 #: src/humanize/time.py:256
 #, python-format
 msgid "%s ago"
-msgstr "%s আগে"
+msgstr "%s দিন আগে"
 
 #: src/humanize/time.py:260
 msgid "now"

--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -20,102 +20,102 @@ msgstr ""
 #: src/humanize/number.py:84
 msgctxt "0 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:85
 msgctxt "1 (male)"
 msgid "st"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:86
 msgctxt "2 (male)"
 msgid "nd"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:87
 msgctxt "3 (male)"
 msgid "rd"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:88
 msgctxt "4 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:89
 msgctxt "5 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:90
 msgctxt "6 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:91
 msgctxt "7 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:92
 msgctxt "8 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:93
 msgctxt "9 (male)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:97
 msgctxt "0 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:98
 msgctxt "1 (female)"
 msgid "st"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:99
 msgctxt "2 (female)"
 msgid "nd"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:100
 msgctxt "3 (female)"
 msgid "rd"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:101
 msgctxt "4 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:102
 msgctxt "5 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:103
 msgctxt "6 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:104
 msgctxt "7 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:105
 msgctxt "8 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:106
 msgctxt "9 (female)"
 msgid "th"
-msgstr ""
+msgstr "তম"
 
 #: src/humanize/number.py:178
 msgid "thousand"

--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -3,6 +3,7 @@
 # This file is distributed under the same license as the humanize package.
 # Wasi Master <arianmollik323@gmail.com>, 2021.
 # Zarif Ahnaf <zarifahnaf@outlook.com>, 2023
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: humanize\n"
@@ -145,32 +146,32 @@ msgstr[1] "%d ট্রিলিয়ন"
 #: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d কোয়াড্রিলিয়ন"
+msgstr[1] "%d কোয়াড্রিলিয়ন"
 
 #: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d কুইন্টিলিয়ন"
+msgstr[1] "%d কুইন্টিলিয়ন"
 
 #: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d সেক্সটিলিয়ন"
+msgstr[1] "%d সেক্সটিলিয়ন"
 
 #: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d সেপটিলিয়ন"
+msgstr[1] "%d সেপটিলিয়ন"
 
 #: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d ওকটিলিয়ন"
+msgstr[1] "%d ওকটিলিয়ন"
 
 #: src/humanize/number.py:187
 msgid "nonillion"


### PR DESCRIPTION
Changes proposed in this pull request:

https://github.com/python-humanize/humanize/blob/a759dd9ca8fbd6366eff09ab7a45d3104a8e548c/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po#L216

Here `পাচ` is not a valid word in bengali. The correct translation for `five` is  `পাঁচ`

---

