### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["pypy3.8", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
@@ -16,7 +16,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.2
+    rev: v2.1.1
     hooks:
       - id: autoflake
         name: autoflake
@@ -61,24 +61,24 @@ repos:
         files: "src/"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.3.0
     hooks:
       - id: mypy
         additional_dependencies: [pytest, types-freezegun, types-setuptools]
         args: [--strict]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.9.2
+    rev: 0.10.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.2
+    rev: v0.13
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.0.0
+    rev: 1.3.0
     hooks:
       - id: tox-ini-fmt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,2 +1,19 @@
-python:
-    pip_install: true
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Project page: https://readthedocs.org/projects/python-humanize/
+
+version: 2
+
+mkdocs:
+  configuration: mkdocs.yml
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+  commands:
+    - pip install -U tox
+    - tox -e docs
+    - mkdir _readthedocs
+    - mv site _readthedocs/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,30 +15,26 @@ keywords = [
 license = {text = "MIT"}
 maintainers = [{name = "Hugo van Kemenade"}]
 authors = [{name = "Jason Moiron", email = "jmoiron@jmoiron.net"}]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Topic :: Text Processing",
-    "Topic :: Text Processing :: General",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Topic :: Text Processing",
+  "Topic :: Text Processing :: General",
 ]
 dynamic = [
   "version",
-]
-dependencies = [
-  'importlib-metadata; python_version < "3.8"',
 ]
 [project.optional-dependencies]
 tests = [
@@ -64,9 +60,6 @@ artifacts = [
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
-
-[tool.black]
-target_version = ["py37"]
 
 [tool.isort]
 profile = "black"

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -1,5 +1,7 @@
 """Main package for humanize."""
 
+import importlib.metadata
+
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, decimal_separator, thousands_separator
 from humanize.number import (
@@ -20,14 +22,7 @@ from humanize.time import (
     precisedelta,
 )
 
-try:
-    # Python 3.8+
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # <Python 3.7 and lower
-    import importlib_metadata  # type: ignore
-
-__version__ = importlib_metadata.version(__name__)
+__version__ = importlib.metadata.version(__name__)
 
 
 __all__ = [

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -106,16 +106,7 @@ def _pgettext(msgctxt: str, message: str) -> str:
     Returns:
         str: Translated text.
     """
-    # This GNU gettext function was added in Python 3.8, so for older versions we
-    # reimplement it. It works by joining `msgctx` and `message` by '4' byte.
-    try:
-        # Python 3.8+
-        return get_translation().pgettext(msgctxt, message)
-    except AttributeError:
-        # Python 3.7 and older
-        key = msgctxt + "\x04" + message
-        translation = get_translation().gettext(key)
-        return message if translation == key else translation
+    return get_translation().pgettext(msgctxt, message)
 
 
 def _ngettext(message: str, plural: str, num: int) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
-envlist =
+requires =
+    tox>=4.2
+env_list =
     docs
     lint
-    py{py3, 312, 311, 310, 39, 38, 37}
+    py{py3, 312, 311, 310, 39, 38}
 
 [testenv]
 extras =
     tests
-passenv =
+pass_env =
     FORCE_COLOR
 commands =
     {envpython} -m pytest --cov humanize --cov tests --cov-report xml {posargs}
@@ -22,7 +24,7 @@ commands =
 skip_install = true
 deps =
     pre-commit
-passenv =
+pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Changes proposed in this pull request:

 * Drop support for Python 3.7, EOL this month
   * https://devguide.python.org/versions/
   * https://peps.python.org/pep-0537/
 * Not planning a major bump, `requires-python = ">=3.8"` makes sure people get the right version
