### PR TITLE
Declare support for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Text Processing",


### PR DESCRIPTION
Python 3.12 is now in beta, let's declare support.

* https://peps.python.org/pep-0693/
* https://discuss.python.org/t/python-3-12-beta-1-and-feature-freeze-is-here/26982?u=hugovk
* https://dev.to/hugovk/help-test-python-312-beta-1508