### PR TITLE
Remove unused MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include src/humanize/locale *.mo


### PR DESCRIPTION
We're using hatchling and hatch-vcs and:

```toml
[tool.hatch.build]
artifacts = [
  "*.mo",
]
```