### PR TITLE
Propose zh_CN translation for "thousand" to be "千"

### DIFF
--- a/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/zh_CN/LC_MESSAGES/humanize.po
@@ -121,8 +121,8 @@ msgstr "第"
 #: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "千"
+msgstr[1] "千"
 
 #: src/humanize/number.py:179
 msgid "million"


### PR DESCRIPTION
Propose zh_CN translation for "thousand" to be "千"

Fixes #126

Changes proposed in this pull request:

* Make zh_CN localization for "thousand" to "千", though according to _General rules for writing numerals in public texts_ of GB/T 15835-2011, it's not right to write "4,000" as "4.0千". But however I think it's better than "4.0 thousand". Hope more Chinese users could give their opinions.

