### PR TITLE
Update docs link to https://humanize.readthedocs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/humanize.svg?logo=pypi&logoColor=FFE873)](https://pypi.org/project/humanize/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/humanize.svg?logo=python&logoColor=FFE873)](https://pypi.org/project/humanize/)
-[![Documentation Status](https://readthedocs.org/projects/python-humanize/badge/?version=latest)](https://python-humanize.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/python-humanize/badge/?version=latest)](https://humanize.readthedocs.io/en/latest/?badge=latest)
 [![PyPI downloads](https://img.shields.io/pypi/dm/humanize.svg)](https://pypistats.org/packages/humanize)
 [![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
 [![codecov](https://codecov.io/gh/python-humanize/humanize/branch/main/graph/badge.svg)](https://codecov.io/gh/python-humanize/humanize)
@@ -44,7 +44,7 @@ human-readable size or throughput. It is localized to:
 
 ## API reference
 
-[https://python-humanize.readthedocs.io](https://python-humanize.readthedocs.io)
+[https://humanize.readthedocs.io](https://humanize.readthedocs.io/)
 
 <!-- usage-start -->
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: humanize
-site_url: https://python-humanize.readthedocs.io
+site_url: https://humanize.readthedocs.io
 repo_url: https://github.com/python-humanize/humanize
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ tests = [
   "pytest-cov",
 ]
 [project.urls]
-Documentation = "https://python-humanize.readthedocs.io/"
+Documentation = "https://humanize.readthedocs.io/"
 Funding = "https://tidelift.com/subscription/pkg/pypi-humanize?utm_source=pypi-humanize&utm_medium=pypi"
 Homepage = "https://github.com/python-humanize/humanize"
 "Issue tracker" = "https://github.com/python-humanize/humanize/issues"


### PR DESCRIPTION
Re: https://github.com/readthedocs/readthedocs.org/issues/10420

We now have the original URL available again for the project.
