### PR TITLE
Fix args for stricter Google docstring parsing by Griffe

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,10 @@
 
 Welcome to the humanize API reference.
 
-* [Number](number)
-* [Time](time)
-* [Filesize](filesize)
-* [I18n](i18n)
+* [Number](number.md)
+* [Time](time.md)
+* [Filesize](filesize.md)
+* [I18n](i18n.md)
 
 {%
    include-markdown "../README.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,8 +25,6 @@ nav:
 plugins:
   - search
   - mkdocstrings:
-      watch:
-        - src/humanize
   - include-markdown
 
 markdown_extensions:
@@ -37,3 +35,6 @@ markdown_extensions:
 
 extra_css:
   - css/code_select.css
+
+watch:
+  - src/humanize

--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -40,6 +40,7 @@ def naturalsize(
         '-4.0 KiB'
 
         ```
+
     Args:
         value (int, float, str): Integer to convert.
         binary (bool): If `True`, uses binary suffixes (KiB, MiB) with base

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -64,6 +64,7 @@ def ordinal(value: NumberOrString, gender: str = "male") -> str:
         True
 
         ```
+
     Args:
         value (int, str, float): Integer to convert.
         gender (str): Gender for translations. Accepts either "male" or "female".
@@ -134,6 +135,7 @@ def intcomma(value: NumberOrString, ndigits: int | None = None) -> str:
         'None'
 
         ```
+
     Args:
         value (int, float, str): Integer or float to convert.
         ndigits (int, None): Digits of precision for rounding after the decimal point.
@@ -213,6 +215,7 @@ def intword(value: NumberOrString, format: str = "%.1f") -> str:
         '1.234 million'
 
         ```
+
     Args:
         value (int, float, str): Integer to convert.
         format (str): To change the number of decimal or general format of the number
@@ -280,6 +283,7 @@ def apnumber(value: NumberOrString) -> str:
       'None'
 
       ```
+
     Args:
         value (int, float, str): Integer to convert.
 
@@ -342,6 +346,7 @@ def fractional(value: NumberOrString) -> str:
         'None'
 
         ```
+
     Args:
         value (int, float, str): Integer to convert.
 


### PR DESCRIPTION
Re: https://github.com/mkdocstrings/griffe/commit/6a8a2280f8910d4268380400d7888cb8d72b4296 and https://github.com/mkdocstrings/griffe/issues/204

Griffe [0.35.2](https://github.com/mkdocstrings/griffe/releases/tag/0.35.2) has stricter parsing of Google docstrings, and needs a newline before the `args:` section.

After 0.35.2 without the fix:

<img width="718" alt="image" src="https://github.com/python-humanize/humanize/assets/1324225/74224936-d471-46a2-b1cc-bb3d394300c1">

Before 0.35.2, and after with this PR:

<img width="718" alt="image" src="https://github.com/python-humanize/humanize/assets/1324225/04f4c911-abc3-490b-b89a-9d3b1aa3d62f">

---

Also fix some warnings:

```
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'number', it was left as is. Did you mean 'number.md'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'time', it was left as is. Did you mean 'time.md'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'filesize', it was left as is. Did you mean 'filesize.md'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'i18n', it was left as is. Did you mean 'i18n.md'?
```

---

Also fix a deprecation warning:

Before:

```console
❯ mkdocs serve
INFO    -  Building documentation...
INFO    -  mkdocstrings: DEPRECATION: mkdocstrings' watch feature is deprecated in favor of MkDocs' watch feature, see https://www.mkdocs.org/user-guide/configuration/#watch
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.39 seconds
INFO    -  [13:11:27] Watching paths for changes: 'docs', 'mkdocs.yml', 'src/humanize', 'README.md'
INFO    -  [13:11:27] Serving on http://127.0.0.1:8000/
```

After:

```console
❯ mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.42 seconds
INFO    -  [13:26:23] Watching paths for changes: 'docs', 'mkdocs.yml', 'README.md', 'src/humanize'
INFO    -  [13:26:23] Serving on http://127.0.0.1:8000/
```


