### PR TITLE
Require PR label: Update permissions

### DIFF
--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,6 +8,10 @@ jobs:
   label:
     runs-on: ubuntu-latest
 
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:


### PR DESCRIPTION
To match the examples at https://github.com/mheap/github-action-required-labels, hopefully will fix the "Approve and run" showing up ([for example](https://github.com/python-humanize/humanize/pull/149)):

<img width="849" alt="image" src="https://github.com/python-humanize/humanize/assets/1324225/de378fa7-5292-40df-bdb3-2b744d95f1ee">

And:

<img width="424" alt="image" src="https://github.com/python-humanize/humanize/assets/1324225/a6614b35-55b9-4f8b-bf6c-d733dcd049f2">

