### PR TITLE
Ignore `DeprecationWarning` caused by dateutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,11 @@ known-first-party = ["humanize"]
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"
+filterwarnings = [
+    "error",
+    # https://github.com/dateutil/dateutil/issues/1314
+    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz",
+]
 
 [tool.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Before:

```
================================================================== warnings summary ==================================================================
../../../../Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 548 passed, 23 skipped, 1 warning in 1.03s =====================================================
```

After:

```
========================================================== 548 passed, 23 skipped in 1.05s ===========================================================
```


This was fixed in dateutil in June: https://github.com/dateutil/dateutil/pull/1285

We're just waiting for the next release: https://github.com/dateutil/dateutil/issues/1314
