### PR TITLE
Fix naturaldelta sub second precision

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -104,7 +104,7 @@ def naturaldelta(
     Returns:
         str (str or `value`): A natural representation of the amount of time
             elapsed unless `value` is not datetime.timedelta or cannot be
-            converted to int (cannot be float due to 'inf' or 'nan).
+            converted to int (cannot be float due to 'inf' or 'nan').
             In that case, a `value` is returned unchanged.
 
     Raises:

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -104,7 +104,8 @@ def naturaldelta(
     Returns:
         str (str or `value`): A natural representation of the amount of time
             elapsed unless `value` is not datetime.timedelta or cannot be
-            converted to float. In that case, a `value` is returned unchanged.
+            converted to int (cannot be float due to 'inf' or 'nan).
+            In that case, a `value` is returned unchanged.
 
     Raises:
         OverflowError: If `value` is too large to convert to datetime.timedelta.
@@ -131,6 +132,7 @@ def naturaldelta(
         delta = value
     else:
         try:
+            int(value)  # Explicitly don't support string such as "NaN" or "inf"
             value = float(value)
             delta = dt.timedelta(seconds=value)
         except (ValueError, TypeError):

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -104,7 +104,7 @@ def naturaldelta(
     Returns:
         str (str or `value`): A natural representation of the amount of time
             elapsed unless `value` is not datetime.timedelta or cannot be
-            converted to int. In that case, a `value` is returned unchanged.
+            converted to float. In that case, a `value` is returned unchanged.
 
     Raises:
         OverflowError: If `value` is too large to convert to datetime.timedelta.
@@ -131,7 +131,7 @@ def naturaldelta(
         delta = value
     else:
         try:
-            value = int(value)
+            value = float(value)
             delta = dt.timedelta(seconds=value)
         except (ValueError, TypeError):
             return str(value)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -129,6 +129,7 @@ def test_naturaldelta_nomonths(test_input: dt.timedelta, expected: str) -> None:
 def test_naturaldelta(test_input: float | dt.timedelta, expected: str) -> None:
     assert humanize.naturaldelta(test_input) == expected
 
+
 @freeze_time("2020-02-02")
 @pytest.mark.parametrize(
     "test_input, expected",

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -126,9 +126,8 @@ def test_naturaldelta_nomonths(test_input: dt.timedelta, expected: str) -> None:
         (dt.timedelta(days=999_999_999), "2,739,726 years"),
     ],
 )
-def test_naturaldelta(test_input: int | dt.timedelta, expected: str) -> None:
+def test_naturaldelta(test_input: float | dt.timedelta, expected: str) -> None:
     assert humanize.naturaldelta(test_input) == expected
-
 
 @freeze_time("2020-02-02")
 @pytest.mark.parametrize(
@@ -339,6 +338,7 @@ def test_naturaldelta_minimum_unit_explicit(
 
     # Act / Assert
     assert humanize.naturaldelta(delta, minimum_unit=minimum_unit) == expected
+    assert humanize.naturaldelta(seconds, minimum_unit=minimum_unit) == expected
 
 
 @freeze_time("2020-02-02")


### PR DESCRIPTION
Fixes #154 

Changes proposed in this pull request:

* Convert to float and not to int
* Explicitly drop support from 'inf' & 'nan' that are supported by float
* In tests, assert both float & timedelta variants are equivalent
