### PR TITLE
Replace deprecated pydocstyle with Ruff and update to Black 2024 style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.2.1
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
 
@@ -31,13 +31,13 @@ repos:
         args: [--strict, --pretty, --show-error-codes]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 1.5.3
+    rev: 1.7.0
     hooks:
       - id: pyproject-fmt
         additional_dependencies: [tox]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.15
+    rev: v0.16
     hooks:
       - id: validate-pyproject
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,6 @@ repos:
       - id: trailing-whitespace
         exclude: \.github/ISSUE_TEMPLATE\.md|\.github/PULL_REQUEST_TEMPLATE\.md
 
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        args: ["--convention", "google"]
-        files: "src/"
-
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,20 +63,23 @@ artifacts = [
 local_scheme = "no-local-version"
 
 [tool.ruff]
-line-length = 88
+fix = true
+
+[tool.ruff.lint]
 select = [
+  "C4", # flake8-comprehensions
   "D", # pydocstyle
   "E", # pycodestyle errors
   "EM", # flake8-errmsg
   "F", # pyflakes errors
   "I", # isort
   "ISC", # flake8-implicit-str-concat
+  "LOG", # flake8-logging
   "PGH", # pygrep-hooks
   "RUF100", # unused noqa (yesqa)
   "UP", # pyupgrade
   "W", # pycodestyle warnings
   "YTT", # flake8-2020
-  # "LOG", # TODO: enable flake8-logging when it's not in preview anymore
 ]
 extend-ignore = [
   "E203", # Whitespace before ':'
@@ -85,9 +88,9 @@ extend-ignore = [
   "E241", # Multiple spaces after ','
 ]
 
-[tool.ruff.isort]
-required-imports = ["from __future__ import annotations"]
+[tool.ruff.lint.isort]
 known-first-party = ["humanize"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ local_scheme = "no-local-version"
 [tool.ruff]
 line-length = 88
 select = [
+  "D", # pydocstyle
   "E", # pycodestyle errors
   "EM", # flake8-errmsg
   "F", # pyflakes errors
@@ -88,6 +89,12 @@ extend-ignore = [
 required-imports = ["from __future__ import annotations"]
 known-first-party = ["humanize"]
 
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D"]
+
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = [
@@ -95,6 +102,3 @@ filterwarnings = [
     # https://github.com/dateutil/dateutil/issues/1314
     "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz",
 ]
-
-[tool.pydocstyle]
-convention = "google"

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -1,4 +1,5 @@
 """Activate, get and deactivate translations."""
+
 from __future__ import annotations
 
 import gettext as gettext_module

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -1,4 +1,5 @@
 """Humanizing functions for numbers."""
+
 from __future__ import annotations
 
 import math

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -2,6 +2,7 @@
 
 These are largely borrowed from Django's `contrib.humanize`.
 """
+
 from __future__ import annotations
 
 import collections.abc

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -109,7 +109,7 @@ def naturaldelta(
     Raises:
         OverflowError: If `value` is too large to convert to datetime.timedelta.
 
-    Examples
+    Examples:
         Compare two timestamps in a custom local timezone::
 
         import datetime as dt

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,4 +1,5 @@
 """Internationalisation tests."""
+
 from __future__ import annotations
 
 import datetime as dt

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,4 +1,5 @@
 """Number tests."""
+
 from __future__ import annotations
 
 import math

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,5 @@
 """Tests for time humanizing."""
+
 from __future__ import annotations
 
 import datetime as dt


### PR DESCRIPTION
Re: https://github.com/PyCQA/pydocstyle/pull/658

Also update pre-commit, and Black to 2024 style, and fix Ruff deprecation warnings.
