### PR TITLE
Set COVERAGE_CORE=sysmon for faster test coverage on 3.12+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3.1.5
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,9 @@ convention = "google"
 [tool.pytest.ini_options]
 addopts = "--color=yes"
 filterwarnings = [
-    "error",
-    # https://github.com/dateutil/dateutil/issues/1314
-    "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz",
+  "error",
+  # https://github.com/dateutil/dateutil/issues/1314
+  "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz",
+  # Python <= 3.11
+  "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ extras =
     tests
 pass_env =
     FORCE_COLOR
+set_env =
+    COVERAGE_CORE = sysmon
 commands =
     {envpython} -m pytest \
       --cov humanize \
@@ -22,7 +24,7 @@ commands =
 
 [testenv:docs]
 deps =
-    -rdocs/requirements.txt
+    -r docs/requirements.txt
 commands =
     mkdocs build
 


### PR DESCRIPTION
Python 3.12 introduced [sys.monitoring](https://docs.python.org/3/library/sys.monitoring.html), that tools like coverage.py can use to improve performance.

It's not yet the default in coverage.py. To enable, we can set a `COVERAGE_CORE=sysmon` environment variable, that will switch to the faster mode when available, that is, in Python 3.12 and newer. Older versions will stick to the older method.

Not a huge difference with these fast tests, but reduces from ~2.93s seconds to 1.86s, about a third.