### PR TITLE
Add 'humanize' command-line interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ Homepage = "https://github.com/python-humanize/humanize"
 "Issue tracker" = "https://github.com/python-humanize/humanize/issues"
 "Release notes" = "https://github.com/python-humanize/humanize/releases"
 Source = "https://github.com/python-humanize/humanize"
+[project.scripts]
+humanize = "humanize.cli.main:main"
 
 [tool.hatch]
 version.source = "vcs"
@@ -97,6 +99,7 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]
+"src/humanize/cli/argutils.py" = ["UP006"]
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"

--- a/src/humanize/__main__.py
+++ b/src/humanize/__main__.py
@@ -1,0 +1,8 @@
+"""Enables to run CLI through `python -m humanize`."""
+
+from __future__ import annotations
+
+from humanize.cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/humanize/cli/__init__.py
+++ b/src/humanize/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI package for humanize."""

--- a/src/humanize/cli/anntype.py
+++ b/src/humanize/cli/anntype.py
@@ -1,0 +1,66 @@
+"""Argument type to be used in ArgumentParser."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from argparse import ArgumentTypeError
+from collections import UserList
+from typing import Any
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Callable
+
+    TypeList = UserList[Callable[[str], Any]]
+else:
+    # generics syntax is not supported in standard collections before PEP 585
+    TypeList = UserList
+
+
+class AnnotationType(TypeList):
+    """Argument type based on function's annotation."""
+
+    def __init__(self, initlist: TypeList) -> None:
+        """Use the `of` class method to get an instance from annotation."""
+        super().__init__(initlist)
+        self.annotation = ""
+
+    def __hash__(self) -> int:
+        """ArgumentParser requires each type to be hashable."""
+        return hash(self.annotation)
+
+    def __call__(self, string: str) -> Any:
+        """Attempt conversion."""
+        if self:
+            try:
+                return self[0](string)
+            except (TypeError, ValueError):
+                return AnnotationType.__call__(self[1:], string)
+        else:
+            raise ArgumentTypeError("Can't convert '%s'" % string)
+
+    @classmethod
+    def of(cls, annotation: str) -> AnnotationType:
+        """Construction using type hints in annotation."""
+        argtype = cls(TypeList())
+        argtype.annotation = annotation
+
+        for hint in map(str.strip, annotation.split("|")):
+            try:
+                obj = getattr(builtins, hint)
+            except AttributeError:
+                if hint == "NumberOrString":
+                    argtype.append(str)
+                else:
+                    raise ValueError("Unknown hint '%s' was found" % hint)
+            else:
+                if callable(obj):
+                    argtype.append(obj)  # such as int, str, etc.
+                elif obj is None:
+                    # ignoring the 'None' hint here because ArgumentParser
+                    # doesn't convert None arguments
+                    pass
+                else:
+                    raise ValueError("Unsupported hint '%s' was found" % hint)
+
+        return argtype

--- a/src/humanize/cli/argutils.py
+++ b/src/humanize/cli/argutils.py
@@ -1,0 +1,117 @@
+"""ArgumentParser utilities."""
+
+from __future__ import annotations
+
+import sys
+from abc import ABC
+from argparse import ArgumentParser
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from inspect import Parameter, signature
+from typing import Any, Literal, NamedTuple, Union
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Callable
+    from typing import Tuple  # UP006 is suppressed in this file
+else:
+    # generics syntax is not supported in standard collections before PEP 585
+    from typing import Callable, Tuple
+
+from humanize.cli.anntype import AnnotationType
+
+FilesizeFlag = Literal[
+    "--binary",
+    "--format",
+    "--gnu",
+]
+NumberFlag = Literal[
+    "--ceil",
+    "--ceil-token",
+    "--floor",
+    "--floor-token",
+    "--format",
+    "--gender",
+    "--ndigits",
+    "--precision",
+    "--unit",
+]
+
+ArgFlag = Union[FilesizeFlag, NumberFlag]
+ArgParam = Union[
+    Tuple[Literal["action"], Literal["store_true", "store_false"]],
+    Tuple[Literal["default"], Any],
+    Tuple[Literal["type"], AnnotationType],
+]
+
+ArgFlagParams = Tuple[ArgFlag, Tuple[ArgParam, ...]]
+ArgError = Callable[[str], None]
+ArgHelp = str
+
+LOCALE_HELP = "Language name, e.g. `en_GB`."
+VALUES_HELP = "Values to humanize. If not found, humanizes inputs from stdin."
+HELP_SUFFIX = " (default: `%(default)s`)"
+
+
+class ArgContext(NamedTuple):
+    """Execution context to be set in ArgumentParser."""
+
+    func: Callable[..., Any]
+    type_: AnnotationType
+    error: ArgError
+
+
+class PositionalArgumentFoundError(ValueError):
+    """Raised when an unexpected positional argument is found."""
+
+    def __init__(self, name: str):
+        """Init with an error message that includes the argument name."""
+        super().__init__(f"Positional argument '{name}' was found.")
+
+
+def _extract_flags(parameters: Iterable[Parameter]) -> Iterator[ArgFlagParams]:
+    """Yield flag and its params from function's parameters."""
+    for parameter in parameters:
+        if parameter.default is Parameter.empty:
+            # expect only optional keyword arguments for flags
+            raise PositionalArgumentFoundError(parameter.name)
+
+        kebabed_name = parameter.name.replace("_", "-")
+        flag: ArgFlag = f"--{kebabed_name}"  # type: ignore[assignment]
+        params: Tuple[ArgParam, ...] = (("default", parameter.default),)
+
+        if parameter.default is False:
+            params += (("action", "store_true"),)
+        elif parameter.default is True:
+            params += (("action", "store_false"),)
+            # flip the flag with `--no-` prefix
+            flag = f"--no-{kebabed_name}"  # type: ignore[assignment]
+        else:
+            params += (("type", AnnotationType.of(parameter.annotation)),)
+
+        yield (flag, params)
+
+
+@dataclass(frozen=True)
+class AddArguments(ABC):
+    """Base class to organize functions in sub-classes."""
+
+    func: Callable[..., Any]
+    helps: Tuple[Tuple[ArgFlag, ArgHelp], ...] = ()
+
+    def __call__(self, parser: ArgumentParser) -> None:
+        """Populate parser with function."""
+        parameters = dict(signature(self.func).parameters)
+
+        type_ = AnnotationType.of(parameters.pop("value").annotation)
+        # add value*s* argument using value's argument type
+        parser.add_argument("values", nargs="*", help=VALUES_HELP, type=type_)
+
+        # add flags
+        parser.add_argument("--locale", help=LOCALE_HELP)
+        for flag, params in _extract_flags(parameters.values()):
+            help_ = dict(self.helps)[flag] + HELP_SUFFIX
+            parser.add_argument(flag, help=help_, **dict(params))
+
+        # set execution context
+        context = ArgContext(func=self.func, type_=type_, error=parser.error)
+        parser.set_defaults(context=context)

--- a/src/humanize/cli/filesize.py
+++ b/src/humanize/cli/filesize.py
@@ -1,0 +1,30 @@
+"""AddArguments for filesize module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from humanize.cli.argutils import AddArguments, FilesizeFlag
+
+
+@dataclass(frozen=True)
+class AddNaturalsizeArguments(AddArguments):
+    """naturalsize function from filesize module."""
+
+    helps: tuple[tuple[FilesizeFlag, str], ...] = (
+        (
+            "--binary",
+            """
+             If `True`, uses binary suffixes (KiB, MiB) with base 2**10 instead
+             of 10**3.
+             """,
+        ),
+        (
+            "--gnu",
+            """
+             If `True`, the binary argument is ignored and GNU-style (`ls -sh`
+             style) prefixes are used (K, M) with the 2**10 definition.
+             """,
+        ),
+        ("--format", "Custom formatter."),
+    )

--- a/src/humanize/cli/main.py
+++ b/src/humanize/cli/main.py
@@ -1,0 +1,98 @@
+"""Main for CLI."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+from argparse import ArgumentParser, ArgumentTypeError
+
+from humanize import filesize, i18n, number
+from humanize.cli.argutils import ArgContext
+from humanize.cli.filesize import AddNaturalsizeArguments
+from humanize.cli.number import (
+    AddApnumberArguments,
+    AddClampArguments,
+    AddFractionalArguments,
+    AddIntcommaArguments,
+    AddIntwordArguments,
+    AddMetricArguments,
+    AddOrdinalArguments,
+    AddScientificArguments,
+)
+
+
+def create_parser() -> ArgumentParser:
+    """Create ArgumentParser."""
+    name = __name__.split(".")[0]
+    version = importlib.metadata.version(name)
+    summary = importlib.metadata.metadata(name).get("Summary")
+
+    parser = ArgumentParser(prog=name, description=summary)
+    parser.add_argument(
+        "-v", "--version", action="version", version=f"%(prog)s {version}"
+    )
+
+    subparsers = parser.add_subparsers(metavar="FUNCTION", required=True)
+    funcs = (
+        filesize.naturalsize,
+        number.apnumber,
+        number.clamp,
+        number.fractional,
+        number.intcomma,
+        number.intword,
+        number.metric,
+        number.ordinal,
+        number.scientific,
+    )
+
+    for func in sorted(funcs, key=lambda func: func.__name__):
+        func_doc = getattr(func, "__doc__", "").splitlines()[0]
+        subparser = subparsers.add_parser(func.__name__, help=func_doc)
+
+        cameled_name = "".join(map(str.capitalize, func.__name__.split("_")))
+        add_arguments = {
+            cls.__name__: cls
+            for cls in (
+                AddApnumberArguments,
+                AddClampArguments,
+                AddFractionalArguments,
+                AddIntcommaArguments,
+                AddIntwordArguments,
+                AddMetricArguments,
+                AddNaturalsizeArguments,
+                AddOrdinalArguments,
+                AddScientificArguments,
+            )
+        }[f"Add{cameled_name}Arguments"](func)
+        add_arguments(subparser)
+
+    return parser
+
+
+def main() -> None:
+    """Run humanize command."""
+    kwargs = vars(create_parser().parse_args())
+    context: ArgContext = kwargs.pop("context")
+
+    locale = kwargs.pop("locale")
+    if locale:
+        try:
+            i18n.activate(locale)
+        except FileNotFoundError as e:
+            context.error(f"{e} locale: {locale}")
+
+    values = kwargs.pop("values")
+    if not values:
+        # replacing with iterator wrapping stdin
+        values = map(context.type_, map(str.strip, sys.stdin))
+
+    try:
+        for value in values:
+            try:
+                print(context.func(value, **kwargs))
+            except ValueError as e:
+                context.error(str(e))
+    except ArgumentTypeError as e:
+        context.error(str(e))
+    finally:
+        i18n.deactivate()

--- a/src/humanize/cli/number.py
+++ b/src/humanize/cli/number.py
@@ -1,0 +1,106 @@
+"""AddArguments for number module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from humanize.cli.argutils import AddArguments, NumberFlag
+
+
+@dataclass(frozen=True)
+class AddApnumberArguments(AddArguments):
+    """naturalsize function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class AddClampArguments(AddArguments):
+    """clamp function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        ("--format", "A formatting string."),
+        ("--floor", "Smallest value before clamping."),
+        ("--ceil", "Largest value before clamping."),
+        (
+            "--floor-token",
+            """
+             If value is smaller than floor, token will be prepended to output.
+             """,
+        ),
+        (
+            "--ceil-token",
+            """
+             If value is larger than ceil, token will be prepended to output.
+             """,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class AddFractionalArguments(AddArguments):
+    """fractional function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class AddIntcommaArguments(AddArguments):
+    """intcomma function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        (
+            "--ndigits",
+            """
+             Digits of precision for rounding after the decimal point.
+             """,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class AddIntwordArguments(AddArguments):
+    """intword function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        (
+            "--format",
+            """
+             To change the number of decimal or general format of the number
+             portion.
+             """,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class AddMetricArguments(AddArguments):
+    """metric function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        ("--unit", "Optional base unit."),
+        ("--precision", "The number of digits the output should contain."),
+    )
+
+
+@dataclass(frozen=True)
+class AddOrdinalArguments(AddArguments):
+    """ordinal function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        (
+            "--gender",
+            """
+             Gender for translations. Accepts either "male" or "female".
+             """,
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class AddScientificArguments(AddArguments):
+    """scientific function from number module."""
+
+    helps: tuple[tuple[NumberFlag, str], ...] = (
+        ("--precision", "Number of decimal for first part of the number."),
+    )

--- a/tests/cli/test_anntype.py
+++ b/tests/cli/test_anntype.py
@@ -1,0 +1,49 @@
+"""Tests ArgType."""
+
+from __future__ import annotations
+
+from argparse import ArgumentTypeError
+from typing import Any
+
+import pytest
+
+from humanize.cli.anntype import AnnotationType
+
+
+@pytest.mark.parametrize(
+    "annotation, string, expect",
+    [
+        ("int", "0", 0),
+        ("float | str", "1", 1.0),
+        ("float | str", "spam", "spam"),
+        ("NumberOrString", "1", "1"),
+        ("NumberOrString", "spam", "spam"),
+        ("float | None", "2", 2.0),
+        ("NumberOrString | None", "2", "2"),
+        ("NumberOrString | None", "", ""),
+        ("NumberOrString | None", "None", "None"),
+    ],
+)
+def test_argtype(
+    annotation: str,
+    string: str,
+    expect: Any,
+) -> None:
+    assert AnnotationType.of(annotation)(string) == expect
+
+
+@pytest.mark.parametrize(
+    "annotation, string, exc",
+    [
+        ("int", "spam", ArgumentTypeError),
+        ("Spam", "spam", ValueError),
+        ("Ellipsis", "...", ValueError),
+    ],
+)
+def test_argtype_error(
+    annotation: str,
+    string: str,
+    exc: type[BaseException],
+) -> None:
+    with pytest.raises(exc):
+        AnnotationType.of(annotation)(string)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,121 @@
+"""Tests for CLI main."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from humanize.cli.main import main
+
+
+@pytest.mark.parametrize(
+    "cmd, stdin_lines, stdout_lines",
+    [
+        ("humanize naturalsize 300 40000", None, "300 Bytes\n40.0 kB"),
+        ("humanize naturalsize", "300\n40000\n", "300 Bytes\n40.0 kB"),
+        ("humanize naturalsize 4096 --binary --format %.2f", None, "4.00 KiB"),
+        ("humanize naturalsize -4096 --gnu", None, "-4.0K"),
+        ("humanize apnumber 5", None, "five"),
+        ("humanize apnumber", "9", "nine"),
+        ("humanize clamp", "123.456", "123.456"),
+        ("humanize clamp --floor 5 --ceil 95 3 98", None, "<5.0\n>95.0"),
+        ("humanize clamp --floor 5 --ceil 95", "5\n95", "5.0\n95.0"),
+        ("humanize fractional .5 .9 1/3", None, "1/2\n9/10\n1/3"),
+        ("humanize fractional", ".5\n.9\n1/3", "1/2\n9/10\n1/3"),
+        ("humanize intcomma 10000", None, "10,000"),
+        ("humanize intcomma", "10000", "10,000"),
+        ("humanize intword 1000 4000", None, "1.0 thousand\n4.0 thousand"),
+        ("humanize intword", "1000\n4000", "1.0 thousand\n4.0 thousand"),
+        ("humanize metric --unit V 1500 1e-14", None, "1.50 kV\n10.0 fV"),
+        ("humanize metric --unit V", "1500\n1e-14", "1.50 kV\n10.0 fV"),
+        ("humanize ordinal 0 1 2", None, "0th\n1st\n2nd"),
+        ("humanize ordinal", "0\n1\n2", "0th\n1st\n2nd"),
+        ("humanize scientific 0.1 100", None, "1.00 x 10⁻¹\n1.00 x 10²"),
+        ("humanize scientific", "0.1\n100", "1.00 x 10⁻¹\n1.00 x 10²"),
+    ],
+)
+def test_main(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    cmd: str,
+    stdin_lines: str | None,
+    stdout_lines: str,
+) -> None:
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", cmd.split())
+        m.setattr("sys.stdin", StringIO(stdin_lines or ""))
+        try:
+            main()
+        except SystemExit as e:
+            pytest.fail(f"Unexpected {e} was raised.")
+
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == stdout_lines.splitlines()
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "cmd, stdin_lines, stdout_lines",
+    [
+        ("humanize naturalsize --locale ja_JP", "5", "5 Bytes"),
+        ("humanize apnumber --locale ja_JP", "5", "五"),
+        ("humanize intcomma --locale de_DE 1000,12", None, "1.000,12"),
+        ("humanize intcomma --locale de_DE", "1000,12", "1.000,12"),
+        ("humanize ordinal --locale fr_FR --gender male 1", None, "1er"),
+        ("humanize ordinal --locale fr_FR --gender female", "1", "1ère"),
+    ],
+)
+def test_main_locale(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    cmd: str,
+    stdin_lines: str | None,
+    stdout_lines: str,
+) -> None:
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", cmd.split())
+        m.setattr("sys.stdin", StringIO(stdin_lines or ""))
+        try:
+            main()
+        except SystemExit as e:
+            pytest.fail(f"Unexpected {e} was raised.")
+
+    captured = capsys.readouterr()
+    if "FileNotFoundError" in captured.err:
+        pytest.skip(".mo locale file was not found")
+    assert captured.out.splitlines() == stdout_lines.splitlines()
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "cmd, stdin_lines, stdout_lines, stderr_keyword, exitcode",
+    [
+        ("humanize naturalsize 300 400A", None, "300 Bytes", "400A", 2),
+        ("humanize naturalsize", "300\n400A", "300 Bytes", "400A", 2),
+        ("humanize clamp 3 4A", None, "", "4A", 2),  # exit before execution
+        ("humanize clamp", "3\n4A", "3.0", "4A", 2),  # exit on exception
+    ],
+)
+def test_main_error(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    cmd: str,
+    stdin_lines: str | None,
+    stdout_lines: str,
+    stderr_keyword: str,
+    exitcode: int,
+) -> None:
+    with monkeypatch.context() as m:
+        m.setattr("sys.argv", cmd.split())
+        m.setattr("sys.stdin", StringIO(stdin_lines or ""))
+        try:
+            main()
+        except SystemExit as e:
+            assert e.code == exitcode
+        else:
+            pytest.fail("No SystemExit was caught")
+
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == stdout_lines.splitlines()
+    assert stderr_keyword in captured.err


### PR DESCRIPTION
This PR adds 'humanize' command-line interface, which enables users to run `humanize` directly on the terminal.

**Example of use**:
```console
$ humanize naturalsize 8589934592
8.6 GB
$ humanize naturalsize --binary 8589934592
8.0 GiB
$ echo 8589934592 | python -m humanize naturalsize --format "%.3f"
8.590 GB
$
$ humanize --version
humanize 0.1.dev845
$
$ humanize --help
usage: humanize [-h] [-v] FUNCTION ...

Python humanize utilities

positional arguments:
  FUNCTION
    apnumber     Converts an integer to Associated Press style.
    clamp        Returns number with the specified format, clamped between floor and ceil.
    fractional   Convert to fractional number.
    intcomma     Converts an integer to a string containing commas every three digits.
    intword      Converts a large integer to a friendly text representation.
    metric       Return a value with a metric SI unit-prefix appended.
    naturalsize  Format a number of bytes like a human readable filesize (e.g. 10 kB).
    ordinal      Converts an integer to its ordinal as a string.
    scientific   Return number in string scientific notation z.wq x 10ⁿ.

options:
  -h, --help     show this help message and exit
  -v, --version  show program's version number and exit
$
$ humanize naturalsize --help
usage: humanize naturalsize [-h] [--locale LOCALE] [--binary] [--gnu] [--format FORMAT] [values ...]

positional arguments:
  values           Values to humanize. If not found, humanizes inputs from stdin.

options:
  -h, --help       show this help message and exit
  --locale LOCALE  Language name, e.g. `en_GB`.
  --binary         If `True`, uses binary suffixes (KiB, MiB) with base 2**10 instead of 10**3. (default: `False`)
  --gnu            If `True`, the binary argument is ignored and GNU-style (`ls -sh` style) prefixes are used (K, M) with the 2**10 definition. (default: `False`)
  --format FORMAT  Custom formatter. (default: `%.1f`)
```

Closes #184

Changes proposed in this pull request:

* CLI for `humanize.filesize` and `humanize.number`.
* `humanize.cli` package, which relies on argparse to keep the package dependencies free.
* `humanize.__main__` module for `python -m humanize`.
* Tests.

Note: `humanize.time` is excluded from the scope because it's too hard to process arbitrary date & time inputs.