### PR TITLE
Remove shebang from filesize.py

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -1,4 +1,5 @@
 """Bits and bytes related humanization."""
+
 from __future__ import annotations
 
 suffixes = {

--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 """Bits and bytes related humanization."""
 from __future__ import annotations
 


### PR DESCRIPTION
In #141 shebangs for `number.py` and `time.py` were removed, but `filesystem.py` maintained it.