### PR TITLE
Speedup x 1.85: Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -17,4 +18,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: pip
       - uses: pre-commit/action@v3.0.1
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -U tox
+
+      - name: Mypy
+        run: tox -e mypy

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# hatch-vcs
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,14 +36,6 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        additional_dependencies: [pytest, types-freezegun, types-setuptools]
-        args: [--strict, --pretty, --show-error-codes, .]
-        pass_filenames: false
-
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 2.2.3
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ version.source = "vcs"
 [tool.hatch.build]
 artifacts = [ "*.mo" ]
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/humanize/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,8 @@ filterwarnings = [
   "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
 ]
 testpaths = [ "tests" ]
+
+[tool.mypy]
+pretty = true
+strict = true
+show_error_codes = true

--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.metadata
-
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, decimal_separator, thousands_separator
 from humanize.number import (
@@ -24,8 +22,7 @@ from humanize.time import (
     precisedelta,
 )
 
-__version__ = importlib.metadata.version(__name__)
-
+from ._version import __version__
 
 __all__ = [
     "__version__",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ requires =
 env_list =
     docs
     lint
+    mypy
     py{py3, 313, 312, 311, 310, 39, 38}
 
 [testenv]
@@ -36,6 +37,15 @@ pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy]
+deps =
+    mypy==1.11.2
+    pytest
+    types-freezegun
+    types-setuptools
+commands =
+    mypy --strict --pretty --show-error-codes . {posargs}
 
 [pytest]
 addopts = --color=yes --doctest-modules


### PR DESCRIPTION
Like https://github.com/hugovk/tinytext/pull/195.

With Python 3.13.0rc2:

```sh
python -X importtime -c "import humanize" 2> import.log && tuna import.log
```

# `main`

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/3facca4a-09ce-464e-9655-fcf3a19f05e2">

# PR

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/4a513d4b-61ee-4d4b-bf18-392877681866">

# hyperfine

```console
❯ hyperfine --warmup 32 \
--prepare "git checkout rm-importlib.metadata" 'python3 -c "import humanize # PR"' \
--prepare "git checkout main"                  'python3 -c "import humanize # main"'
Benchmark 1: python3 -c "import humanize # PR"
  Time (mean ± σ):      23.5 ms ±   3.5 ms    [User: 18.0 ms, System: 4.3 ms]
  Range (min … max):    21.8 ms …  43.4 ms    75 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Benchmark 2: python3 -c "import humanize # main"
  Time (mean ± σ):      43.4 ms ±   2.3 ms    [User: 34.5 ms, System: 7.6 ms]
  Range (min … max):    41.8 ms …  52.9 ms    52 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Summary
  python3 -c "import humanize # PR" ran
    1.85 ± 0.29 times faster than python3 -c "import humanize # main"
```

---

Also move mypy from pre-commit to tox, so it runs when the version file has been generated.