### PR TITLE
Defer `fractions.Fraction` import to save 5ms

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import math
 import re
 import sys
-from fractions import Fraction
 from typing import TYPE_CHECKING
 
 from .i18n import _gettext as _
@@ -359,6 +358,8 @@ def fractional(value: NumberOrString) -> str:
             return _format_not_finite(number)
     except (TypeError, ValueError):
         return str(value)
+    from fractions import Fraction
+
     whole_number = int(number)
     frac = Fraction(number - whole_number).limit_denominator(1000)
     numerator = frac.numerator


### PR DESCRIPTION
# `main`

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/4283df4a-f665-483d-b494-3780786cad9f">

# PR

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/11ce05cc-e597-4e87-b60d-934e19463fea">

# hyperfine

```console
❯ hyperfine --warmup 32 \
--prepare "git checkout defer-fractions" 'python3 -c "import humanize # PR"' \
--prepare "git checkout main"            'python3 -c "import humanize # main"'
Benchmark 1: python3 -c "import humanize # PR"
  Time (mean ± σ):      46.1 ms ±  10.7 ms    [User: 34.4 ms, System: 8.5 ms]
  Range (min … max):    39.6 ms …  95.3 ms    55 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Benchmark 2: python3 -c "import humanize # main"
  Time (mean ± σ):      52.7 ms ±  16.7 ms    [User: 38.8 ms, System: 9.1 ms]
  Range (min … max):    41.7 ms … 118.4 ms    46 runs

Summary
  python3 -c "import humanize # PR" ran
    1.14 ± 0.45 times faster than python3 -c "import humanize # main"
```

