### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 license = { text = "MIT" }
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Jason Moiron", email = "jmoiron@jmoiron.net" } ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -23,7 +23,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     docs
     lint
     mypy
-    py{py3, 313, 312, 311, 310, 39, 38}
+    py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan