### PR TITLE
Release to PyPI using Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'python-humanize'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+          repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    if: |
+      github.repository_owner == 'python-humanize'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,66 +5,19 @@
       running cleanly for all merges to `main`.
       [![GitHub Actions status](https://github.com/python-humanize/humanize/workflows/Test/badge.svg)](https://github.com/python-humanize/humanize/actions)
 
-* [ ] Start from a freshly cloned repo:
-
-```bash
-cd /tmp
-rm -rf humanize
-git clone https://github.com/python-humanize/humanize
-cd humanize
-# Generate translation binaries
-scripts/generate-translation-binaries.sh
-```
-
-- [ ] (Optional) Create a distribution and release on **TestPyPI**:
-
-```bash
-pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-twine check --strict dist/* && twine upload --repository testpypi dist/*
-```
-
-- [ ] (Optional) Check **test** installation:
-
-```bash
-pip3 uninstall -y humanize
-pip3 install -U -i https://test.pypi.org/simple/ humanize --pre
-python3 -c "import humanize; print(humanize.__version__)"
-```
-
-- [ ] Tag with the version number:
-
-```bash
-git tag -a 2.1.0 -m "Release 2.1.0"
-```
-
-- [ ] Create a distribution and release on **live PyPI**:
-
-```bash
-pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-twine check --strict dist/* && twine upload --repository pypi dist/*
-```
-
-- [ ] Check installation:
-
-```bash
-pip uninstall -y humanize
-pip install -U humanize
-python3 -c "import humanize; print(humanize.__version__)"
-```
-
-- [ ] Push tag:
-
-```bash
-git push --tags
-```
-
 - [ ] Edit release draft, adjust text if needed:
       https://github.com/python-humanize/humanize/releases
 
 - [ ] Check next tag is correct, amend if needed
 
 - [ ] Publish release
+
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/python-humanize/humanize/actions/workflows/release.yml)
+      has released to [PyPI](https://pypi.org/project/humanize/#history)
+
+- [ ] Check installation:
+
+```bash
+pip3 uninstall -y humanize && pip3 install -U humanize && python3 -c "import humanize; print(humanize.__version__)"
+```


### PR DESCRIPTION
PyPI has introduced "Trusted Publishers", a method to release files from CI using OIDC and generated, short-lived tokens, rather than long-lived tokens on the developer's own machine. This is both safer, and makes releasing easier and more convenient.

https://docs.pypi.org/trusted-publishers/

This PR adds a workflow to deploy to PyPI for new GitHub releases.

It also deploys to Test PyPI on merges to `main`, to make sure the release machinery is well oiled.

I've set up the PyPIs.

* https://test.pypi.org/manage/project/humanize/settings/publishing/
* https://pypi.org/manage/project/humanize/settings/publishing/

---

PEP 740 ("Index support for digital attestations") introduces signatures which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages. This is only available with Trusted Publishing.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871

All we need to do to enable this is add:
```yml
        with:
          attestations: true
```

