### PR TITLE
Fix overflow issue in naturalsize with np.int32 input

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -101,5 +101,5 @@ def naturalsize(
         if abs_bytes < unit:
             break
 
-    ret: str = format % (base * bytes_ / unit) + s
+    ret: str = format % (base * (bytes_ / unit)) + s
     return ret


### PR DESCRIPTION
Fixes #217 

Changes proposed in this pull request:

* Change the order of operations of the return statement in the naturalsize function to ensure all intermediate calculations stay float to prevent overflow issues.