### PR TITLE
Replace deprecated classifier with licence expression (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs",
-  "hatchling",
+  "hatchling>=1.27",
 ]
 
 [project]
@@ -12,14 +12,14 @@ readme = "README.md"
 keywords = [
   "humanize time size",
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = [ "LICENSE" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Jason Moiron", email = "jmoiron@jmoiron.net" } ]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
* https://peps.python.org/pep-0639/
* https://packaging.python.org/en/latest/specifications/core-metadata/
* https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/170

This depends on (at least) all these, thanks to everyone for making it happen:

* packaging 24.2 https://packaging.pypa.io/en/stable/changelog.html
* Hatchling 1.27 https://hatch.pypa.io/dev/history/hatchling/
* Twine 6.1.0 https://twine.readthedocs.io/en/stable/changelog.html
* PyPI publish GitHub Action v1.12.4 https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4
* build-and-inspect-python-package v2.12.0 https://github.com/hynek/build-and-inspect-python-package/releases/tag/v2.12.0
