### PR TITLE
Update license file reference from LICENSE to LICENCE in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = [
   "humanize time size",
 ]
 license = "MIT"
-license-files = [ "LICENSE" ]
+license-files = [ "LICENCE" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Jason Moiron", email = "jmoiron@jmoiron.net" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
The `humanize` package does not currently include the `LICEN[CS]E` file when uploaded to PyPI, causing tools like `pip-license` to fail to detect that this package is MIT licensed. 

By updating the reference to `LICENCE`, we ensure that the correct file is included in the package.