### PR TITLE
Ignore `sys.monitoring` warning for 3.11 and earlier in coverage.py config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,7 @@
 exclude_also =
     # Don't complain if non-runnable code isn't run:
     if TYPE_CHECKING:
+
+[run]
+disable_warnings =
+    no-sysmon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,6 @@ filterwarnings = [
   "error",
   # https://github.com/dateutil/dateutil/issues/1314
   "ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz",
-  # Python <= 3.11
-  "ignore:sys.monitoring isn't available, using default core:coverage.exceptions.CoverageWarning",
 ]
 testpaths = [ "tests" ]
 


### PR DESCRIPTION
The wording of the warning changed slightly from coverage.py 7.6 to 7.7:


```diff
-coverage.exceptions.CoverageWarning: sys.monitoring isn't available, using default core (no-sysmon)
+coverage.exceptions.CoverageWarning: sys.monitoring isn't available in this version, using default core (no-sysmon)
```

So the regex in `pyproject.toml` doesn't match.

Instead, let's use the `no-sysmon` code to disable it directly in coverage.py's config:

* https://coverage.readthedocs.io/en/7.7.1/config.html#run-disable-warnings
* https://coverage.readthedocs.io/en/7.7.1/cmd.html#cmd-warnings
