### PR TITLE
Fix regression in `naturalsize` for float and str

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -91,7 +91,7 @@ def naturalsize(
     abs_bytes = abs(bytes_)
 
     if abs_bytes == 1 and not gnu:
-        return f"{bytes_} Byte"
+        return f"{int(bytes_)} Byte"
 
     if abs_bytes < base:
         return f"{int(bytes_)}B" if gnu else f"{int(bytes_)} Bytes"

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -69,6 +69,8 @@ import humanize
         ([3000000, False, True], "2.9M"),
         ([1024, False, True], "1.0K"),
         ([1, False, False], "1 Byte"),
+        ([1.0, False, False], "1 Byte"),
+        (["1", False, False], "1 Byte"),
         ([3141592, False, False, "%.2f"], "3.14 MB"),
         ([3000, False, True, "%.3f"], "2.930K"),
         ([3000000000, False, True, "%.0f"], "3G"),


### PR DESCRIPTION
Currently if `gnu` is set to False, calling `naturalsize(1.0)` or `naturalsize("1")` will return `"1.0 Byte` instead of `"1 Byte"`, which was the return value until 4.12.