### PR TITLE
Fix naturalday/naturaldate wrong answer for tz-aware datetimes

### DIFF
--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -300,6 +300,51 @@ def test_naturaldate(test_input: dt.date, expected: str) -> None:
     assert humanize.naturaldate(test_input) == expected
 
 
+@freeze_time("2023-10-15 23:00:00", tz_offset=0)
+def test_naturalday_tz_aware() -> None:
+    """Test that naturalday compares dates in the value's timezone, not system local."""
+    # https://github.com/python-humanize/humanize/issues/152
+    utc = dt.timezone.utc
+    aedt = dt.timezone(dt.timedelta(hours=11))
+    edt = dt.timezone(dt.timedelta(hours=-4))
+    pdt = dt.timezone(dt.timedelta(hours=-7))
+
+    # A moment 7 hours in the future (UTC).
+    future = dt.datetime(2023, 10, 16, hour=6, tzinfo=utc)
+
+    # In UTC: now is Oct 15, future is Oct 16 → tomorrow
+    assert humanize.naturalday(future) == "tomorrow"
+
+    # In AEDT (+11): now is Oct 16 10:00, future is Oct 16 17:00 → today
+    assert humanize.naturalday(future.astimezone(aedt)) == "today"
+
+    # In EDT (-4): now is Oct 15 19:00, future is Oct 16 02:00 → tomorrow
+    assert humanize.naturalday(future.astimezone(edt)) == "tomorrow"
+
+    # In PDT (-7): now is Oct 15 16:00, future is Oct 15 23:00 → today
+    assert humanize.naturalday(future.astimezone(pdt)) == "today"
+
+
+@freeze_time("2023-10-15 23:00:00", tz_offset=0)
+def test_naturaldate_tz_aware() -> None:
+    """Test that naturaldate compares dates in the value's timezone, not system local."""
+    # https://github.com/python-humanize/humanize/issues/152
+    utc = dt.timezone.utc
+    aedt = dt.timezone(dt.timedelta(hours=11))
+    edt = dt.timezone(dt.timedelta(hours=-4))
+
+    future = dt.datetime(2023, 10, 16, hour=6, tzinfo=utc)
+
+    # In UTC: tomorrow
+    assert humanize.naturaldate(future) == "tomorrow"
+
+    # In AEDT (+11): today
+    assert humanize.naturaldate(future.astimezone(aedt)) == "today"
+
+    # In EDT (-4): tomorrow
+    assert humanize.naturaldate(future.astimezone(edt)) == "tomorrow"
+
+
 @pytest.mark.parametrize(
     "seconds, expected",
     [

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -327,7 +327,7 @@ def test_naturalday_tz_aware() -> None:
 
 @freeze_time("2023-10-15 23:00:00", tz_offset=0)
 def test_naturaldate_tz_aware() -> None:
-    """Test that naturaldate compares dates in the value's timezone, not system local."""
+    """Test naturaldate compares dates in value's timezone."""
     # https://github.com/python-humanize/humanize/issues/152
     utc = dt.timezone.utc
     aedt = dt.timezone(dt.timedelta(hours=11))


### PR DESCRIPTION
## Summary

When a tz-aware datetime is passed, `naturalday()` and `naturaldate()` extract the date in the value's timezone (via `dt.date(value.year, value.month, value.day)`) but compare it with `dt.date.today()` which uses system local time. This produces wrong results when the value's timezone differs from the system timezone.

**Example from the issue:** When the system is in UTC and it's Oct 15 23:00 UTC (Oct 16 10:00 AEDT), calling `naturaldate()` with an AEDT datetime on Oct 16 should return "today" (both dates are Oct 16 in AEDT), but instead returns "tomorrow" because `date.today()` returns Oct 15 (the system's UTC date).

## Fix

Capture the value's `tzinfo` before converting to a plain date. If a timezone is present, derive "today" via `datetime.now(tzinfo).date()` so both dates are in the same timezone.

## Test plan

- Added `test_naturalday_tz_aware` — tests UTC, AEDT (+11), EDT (-4), PDT (-7) against a future datetime, verifying today/tomorrow is computed relative to each timezone
- Added `test_naturaldate_tz_aware` — same scenario through `naturaldate()`  
- All 46 time tests pass, including all existing tests (no regressions)

Fixes #152