### PR TITLE
Add test for exact googol (10**100) in `intword()`

### DIFF
--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -122,6 +122,7 @@ def test_intword_powers() -> None:
         ([2e100], "2.0 googol"),
         ([None], "None"),
         (["1230000", "%0.2f"], "1.23 million"),
+        ([10**100], "1.0 googol"),
         ([10**101], "10.0 googol"),
         ([math.nan], "NaN"),
         ([math.inf], "+Inf"),


### PR DESCRIPTION
## Summary
This PR adds a test case for exact googol (`10**100`) in `intword()` function.

## Context
- Issue #134 reported that `intword(10**100)` returns the raw number instead of "1.0 googol"
- PR #273 fixed the underlying issue by using `bisect` instead of for-loop
- However, the test for exact googol was not added in that PR
- The existing tests cover `2e100` (2 googols) and `10**101` (10 googols), but not `10**100` (1 googol)

## Changes
Added test case `([10**100], "1.0 googol")` to `tests/test_number.py`

## Testing
The test passes on the current repo code (which already includes the fix from PR #273). This ensures the googol edge case is covered in the test suite for future releases.

Fixes #134