### PR TITLE
Refactor: simplify `scientific()` and extract `_SUPERSCRIPT_MAP` constant

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -9,7 +9,6 @@ from .i18n import _ngettext, decimal_separator, thousands_separator
 from .i18n import _ngettext_noop as NS_
 from .i18n import _pgettext as P_
 
-
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -445,7 +444,6 @@ def scientific(value: NumberOrString, precision: int = 2) -> str:
 
     part2 = re.sub(r"^\+?(\-?)0*(.+)$", r"\1\2", part2)
     return part1 + " x 10" + "".join([_SUPERSCRIPT_MAP[char] for char in part2])
-
 
 
 def clamp(

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -9,6 +9,16 @@ from .i18n import _ngettext, decimal_separator, thousands_separator
 from .i18n import _ngettext_noop as NS_
 from .i18n import _pgettext as P_
 
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import TypeAlias
+
+    # This type can be better defined by typing.SupportsFloat
+    # but that's a Python 3.8 only typing option.
+    NumberOrString: TypeAlias = float | str
+
+
 _SUPERSCRIPT_MAP = {
     "0": "⁰",
     "1": "¹",
@@ -22,14 +32,6 @@ _SUPERSCRIPT_MAP = {
     "9": "⁹",
     "-": "⁻",
 }
-
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from typing import TypeAlias
-
-    # This type can be better defined by typing.SupportsFloat
-    # but that's a Python 3.8 only typing option.
-    NumberOrString: TypeAlias = float | str
 
 
 def _format_not_finite(value: float) -> str:
@@ -442,8 +444,8 @@ def scientific(value: NumberOrString, precision: int = 2) -> str:
     import re
 
     part2 = re.sub(r"^\+?(\-?)0*(.+)$", r"\1\2", part2)
+    return part1 + " x 10" + "".join([_SUPERSCRIPT_MAP[char] for char in part2])
 
-    return part1 + " x 10" + "".join(_SUPERSCRIPT_MAP[char] for char in part2)
 
 
 def clamp(

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -9,6 +9,20 @@ from .i18n import _ngettext, decimal_separator, thousands_separator
 from .i18n import _ngettext_noop as NS_
 from .i18n import _pgettext as P_
 
+_SUPERSCRIPT_MAP = {
+    "0": "⁰",
+    "1": "¹",
+    "2": "²",
+    "3": "³",
+    "4": "⁴",
+    "5": "⁵",
+    "6": "⁶",
+    "7": "⁷",
+    "8": "⁸",
+    "9": "⁹",
+    "-": "⁻",
+}
+
 TYPE_CHECKING = False
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -415,19 +429,6 @@ def scientific(value: NumberOrString, precision: int = 2) -> str:
     """
     import math
 
-    exponents = {
-        "0": "⁰",
-        "1": "¹",
-        "2": "²",
-        "3": "³",
-        "4": "⁴",
-        "5": "⁵",
-        "6": "⁶",
-        "7": "⁷",
-        "8": "⁸",
-        "9": "⁹",
-        "-": "⁻",
-    }
     try:
         value = float(value)
         if not math.isfinite(value):
@@ -442,13 +443,7 @@ def scientific(value: NumberOrString, precision: int = 2) -> str:
 
     part2 = re.sub(r"^\+?(\-?)0*(.+)$", r"\1\2", part2)
 
-    new_part2 = []
-    for char in part2:
-        new_part2.append(exponents[char])
-
-    final_str = part1 + " x 10" + "".join(new_part2)
-
-    return final_str
+    return part1 + " x 10" + "".join(_SUPERSCRIPT_MAP[char] for char in part2)
 
 
 def clamp(


### PR DESCRIPTION
Cool repo! I made a small cleanup to the scientific() function in number.py.

I extracted the exponents dict as a module-level constant so it's not recreated on every function call. I also simplified the character mapping loop into a generator expression.

I'm happy to make any changes if necessary. Hope this helps! 
