### PR TITLE
Performance improvements: 1.07x - 8.4x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ lint.select = [
   "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
+  "PERF",   # perflint
   "PGH",    # pygrep-hooks
   "PIE",    # flake8-pie
   "PT",     # flake8-pytest-style

--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -19,7 +19,7 @@ _CURRENT = local()
 
 
 # Mapping of locale to thousands separator
-_THOUSANDS_SEPARATOR = {
+_THOUSANDS_SEPARATOR: dict[str | None, str] = {
     "de_DE": ".",
     "fr_FR": " ",
     "it_IT": ".",
@@ -29,7 +29,7 @@ _THOUSANDS_SEPARATOR = {
 }
 
 # Mapping of locale to decimal separator
-_DECIMAL_SEPARATOR = {
+_DECIMAL_SEPARATOR: dict[str | None, str] = {
     "de_DE": ",",
     "fr_FR": ".",
     "it_IT": ",",
@@ -51,10 +51,7 @@ def _get_default_locale_path() -> pathlib.Path | None:
 
 
 def get_translation() -> gettext_module.NullTranslations:
-    try:
-        return _TRANSLATIONS[_CURRENT.locale]
-    except (AttributeError, KeyError):
-        return _TRANSLATIONS[None]
+    return _TRANSLATIONS.get(getattr(_CURRENT, "locale", None), _TRANSLATIONS[None])
 
 
 def activate(
@@ -188,11 +185,7 @@ def thousands_separator() -> str:
     Returns:
          str: Thousands separator.
     """
-    try:
-        sep = _THOUSANDS_SEPARATOR[_CURRENT.locale]
-    except (AttributeError, KeyError):
-        sep = ","
-    return sep
+    return _THOUSANDS_SEPARATOR.get(getattr(_CURRENT, "locale", None), ",")
 
 
 def decimal_separator() -> str:
@@ -201,8 +194,4 @@ def decimal_separator() -> str:
     Returns:
          str: Decimal separator.
     """
-    try:
-        sep = _DECIMAL_SEPARATOR[_CURRENT.locale]
-    except (AttributeError, KeyError):
-        sep = "."
-    return sep
+    return _DECIMAL_SEPARATOR.get(getattr(_CURRENT, "locale", None), ".")

--- a/src/humanize/lists.py
+++ b/src/humanize/lists.py
@@ -33,4 +33,4 @@ def natural_list(items: list[Any]) -> str:
     elif len(items) == 2:
         return f"{str(items[0])} and {str(items[1])}"
     else:
-        return ", ".join(str(item) for item in items[:-1]) + f" and {str(items[-1])}"
+        return ", ".join([str(item) for item in items[:-1]]) + f" and {str(items[-1])}"

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -32,6 +32,8 @@ _SUPERSCRIPT_MAP = {
     "-": "⁻",
 }
 
+_ORDINAL_SUFFIXES = ("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
+
 
 def _format_not_finite(value: float) -> str:
     """Utility function to handle infinite and nan cases."""
@@ -91,35 +93,9 @@ def ordinal(value: NumberOrString, gender: str = "male") -> str:
         value = int(value)
     except (TypeError, ValueError):
         return str(value)
-    if gender == "male":
-        t = (
-            P_("0 (male)", "th"),
-            P_("1 (male)", "st"),
-            P_("2 (male)", "nd"),
-            P_("3 (male)", "rd"),
-            P_("4 (male)", "th"),
-            P_("5 (male)", "th"),
-            P_("6 (male)", "th"),
-            P_("7 (male)", "th"),
-            P_("8 (male)", "th"),
-            P_("9 (male)", "th"),
-        )
-    else:
-        t = (
-            P_("0 (female)", "th"),
-            P_("1 (female)", "st"),
-            P_("2 (female)", "nd"),
-            P_("3 (female)", "rd"),
-            P_("4 (female)", "th"),
-            P_("5 (female)", "th"),
-            P_("6 (female)", "th"),
-            P_("7 (female)", "th"),
-            P_("8 (female)", "th"),
-            P_("9 (female)", "th"),
-        )
-    if value % 100 in (11, 12, 13):  # special case
-        return f"{value}{t[0]}"
-    return f"{value}{t[value % 10]}"
+    gender = "male" if gender == "male" else "female"
+    digit = 0 if value % 100 in (11, 12, 13) else value % 10
+    return f"{value}{P_(f'{digit} ({gender})', _ORDINAL_SUFFIXES[digit])}"
 
 
 def intcomma(value: NumberOrString, ndigits: int | None = None) -> str:

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -33,6 +33,18 @@ _SUPERSCRIPT_MAP = {
 }
 
 _ORDINAL_SUFFIXES = ("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
+_APNUMBER_WORDS = (
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+)
 
 
 def _format_not_finite(value: float) -> str:
@@ -295,18 +307,7 @@ def apnumber(value: NumberOrString) -> str:
         return str(value)
     if not 0 <= value < 10:
         return str(value)
-    return (
-        _("zero"),
-        _("one"),
-        _("two"),
-        _("three"),
-        _("four"),
-        _("five"),
-        _("six"),
-        _("seven"),
-        _("eight"),
-        _("nine"),
-    )[value]
+    return _(_APNUMBER_WORDS[value])
 
 
 def fractional(value: NumberOrString) -> str:

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -165,17 +165,12 @@ def intcomma(value: NumberOrString, ndigits: int | None = None) -> str:
         return str(value)
 
     if ndigits is not None:
-        orig = "{0:.{1}f}".format(value, ndigits)
+        result = f"{value:,.{ndigits}f}"
     else:
-        orig = str(value)
-    orig = orig.replace(".", decimal_sep)
-    import re
-
-    while True:
-        new = re.sub(r"^(-?\d+)(\d{3})", rf"\g<1>{thousands_sep}\g<2>", orig)
-        if orig == new:
-            return new
-        orig = new
+        result = f"{value:,}"
+    if thousands_sep != "," or decimal_sep != ".":
+        result = result.translate(str.maketrans(",.", thousands_sep + decimal_sep))
+    return result
 
 
 powers = [10**x for x in (3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 100)]

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -31,6 +31,7 @@ _SUPERSCRIPT_MAP = {
     "9": "⁹",
     "-": "⁻",
 }
+_SUPERSCRIPT_TRANS = str.maketrans(_SUPERSCRIPT_MAP)
 
 _ORDINAL_SUFFIXES = ("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
 _APNUMBER_WORDS = (
@@ -408,14 +409,12 @@ def scientific(value: NumberOrString, precision: int = 2) -> str:
             return _format_not_finite(value)
     except (ValueError, TypeError):
         return str(value)
-    fmt = f"{{:.{str(int(precision))}e}}"
+    fmt = f"{{:.{int(precision)}e}}"
     n = fmt.format(value)
     part1, part2 = n.split("e")
-    # Remove redundant leading '+' or '0's (preserving the last '0' for 10⁰).
-    import re
-
-    part2 = re.sub(r"^\+?(\-?)0*(.+)$", r"\1\2", part2)
-    return part1 + " x 10" + "".join([_SUPERSCRIPT_MAP[char] for char in part2])
+    # Normalise exponent: int() strips the "+" sign and leading zeros,
+    # while preserving "-" and a single "0" for 10⁰.
+    return part1 + " x 10" + str(int(part2)).translate(_SUPERSCRIPT_TRANS)
 
 
 def clamp(

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -631,14 +631,14 @@ def precisedelta(
         ("%d microsecond", "%d microseconds", usecs),
     ]
 
+    import math
+
     texts: list[str] = []
     for unit, fmt in zip(reversed(Unit), fmts):
         singular_txt, plural_txt, fmt_value = fmt
         if fmt_value > 0 or (not texts and unit == min_unit):
             _fmt_value = 2 if 1 < fmt_value < 2 else int(fmt_value)
             fmt_txt = _ngettext(singular_txt, plural_txt, _fmt_value)
-            import math
-
             if unit == min_unit and math.modf(fmt_value)[0] > 0:
                 fmt_txt = fmt_txt.replace("%d", format)
             elif unit == YEARS:

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -301,6 +301,9 @@ def _convert_aware_datetime(
     value: dt.datetime | dt.timedelta | float | None,
 ) -> Any:
     """Convert aware datetime to naive datetime and pass through any other type."""
+    if value is None:
+        return None
+
     import datetime as dt
 
     if isinstance(value, dt.datetime) and value.tzinfo is not None:

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -552,9 +552,13 @@ def precisedelta(
     secs = delta.seconds
     usecs = delta.microseconds
 
-    MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS, MONTHS, YEARS = list(
-        Unit
-    )
+    MILLISECONDS = Unit.MILLISECONDS
+    SECONDS = Unit.SECONDS
+    MINUTES = Unit.MINUTES
+    HOURS = Unit.HOURS
+    DAYS = Unit.DAYS
+    MONTHS = Unit.MONTHS
+    YEARS = Unit.YEARS
 
     # Given DAYS compute YEARS and the remainder of DAYS as follows:
     #   if YEARS is the minimum unit, we cannot use DAYS so


### PR DESCRIPTION
With this benchmark script:

<details>
<summary>Details</summary>


```python
from __future__ import annotations

import datetime as dt
import timeit

import humanize

_WHEN = dt.datetime.now() - dt.timedelta(hours=3, minutes=27)
_DELTA = dt.timedelta(days=2, hours=3, seconds=4)

CASES = [
    ("ordinal(123)",            lambda: humanize.ordinal(123)),
    ("apnumber(7)",             lambda: humanize.apnumber(7)),
    ("intcomma(1_234_567_890)", lambda: humanize.intcomma(1_234_567_890)),
    ("scientific(-1.234e-50)",  lambda: humanize.scientific(-1.234e-50)),
    ("natural_list(4 items)",   lambda: humanize.natural_list(["one", "two", "three", "four"])),
    ("naturaltime(3h27m ago)",  lambda: humanize.naturaltime(_WHEN)),
    ("precisedelta(2d 3h 4s)",  lambda: humanize.precisedelta(_DELTA)),
]

NUMBER = 200_000
REPEAT = 10
WARMUP = 100


def main() -> None:
    print(f"humanize: {humanize.__version__}")
    print(f"{NUMBER:,} calls per round, {REPEAT} rounds\n")
    print(f"{'case':32s}  {'min ns':>10s}  {'median ns':>10s}")
    print("-" * 56)
    for name, fn in CASES:
        for _ in range(WARMUP):
            fn()
        times = timeit.repeat(fn, number=NUMBER, repeat=REPEAT)
        times.sort()
        print(f"{name:32s}  {min(times)/NUMBER*1e9:10.0f}  "
              f"{times[len(times)//2]/NUMBER*1e9:10.0f}")


if __name__ == "__main__":
    main()
```

</details>

```
humanize: 4.15.0
200,000 calls per round, 10 rounds

case                                  min ns   median ns
--------------------------------------------------------
ordinal(123)                            3634        3673
apnumber(7)                             3587        3764
intcomma(1_234_567_890)                 3287        3508
scientific(-1.234e-50)                  1311        1329
natural_list(4 items)                    425         435
naturaltime(3h27m ago)                  2710        2726
precisedelta(2d 3h 4s)                  8964        9046
``` 
```
humanize: 4.15.1.dev37
200,000 calls per round, 10 rounds

case                                  min ns   median ns
--------------------------------------------------------
ordinal(123)                             594         596
apnumber(7)                              429         439
intcomma(1_234_567_890)                 1026        1514
scientific(-1.234e-50)                   633         928
natural_list(4 items)                    323         466
naturaltime(3h27m ago)                  2528        2580
precisedelta(2d 3h 4s)                  8319        8521
```




| Function | 4.15.0 | PR | Speedup |
|---|---|---|---|
| `ordinal(123)` | 3634 ns | 594 ns | **6.1x** |
| `apnumber(7)` | 3587 ns | 429 ns | **8.4x** |
| `intcomma(1_234_567_890)` | 3287 ns | 1026 ns | **3.2x** |
| `scientific(-1.234e-50)` | 1311 ns | 633 ns | **2.1x** |
| `natural_list(4 items)` | 425 ns | 323 ns | **1.3x** |
| `naturaltime(3h27m ago)` | 2710 ns | 2528 ns | **1.07x** |
| `precisedelta(2d 3h 4s)` | 8964 ns | 8319 ns | **1.08x** |