### PR TITLE
Return an empty string from `natural_list()` for an empty list

### DIFF
--- a/src/humanize/lists.py
+++ b/src/humanize/lists.py
@@ -28,6 +28,8 @@ def natural_list(items: list[Any]) -> str:
     Returns:
         str: A string with commas and 'and' in the right places.
     """
+    if not items:
+        return ""
     if len(items) == 1:
         return str(items[0])
     elif len(items) == 2:

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -12,6 +12,7 @@ import humanize
         ([["one", "two", "three"]], "one, two and three"),
         ([["one", "two"]], "one and two"),
         ([["one"]], "one"),
+        ([[]], ""),
         ([[""]], ""),
         ([[1, 2, 3]], "1, 2 and 3"),
         ([[1, "two"]], "1 and two"),


### PR DESCRIPTION
`natural_list([])` raises `IndexError`:

```pycon
>>> import humanize
>>> humanize.natural_list([])
IndexError: list index out of range
```

With no items, neither the `len == 1` nor `len == 2` branch matches, so it falls through to the general branch which does `items[-1]` on an empty list.

An empty list of items naturally renders as an empty string (consistent with `natural_list([""])` already returning `""`), so this guards that case up front. Added `([[]], "")` to the `test_natural_list` parametrize list.