### PR TITLE
Stop printing two minus signs in fractional for a negative mixed number

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -367,7 +367,12 @@ def fractional(value: NumberOrString) -> str:
     if not whole_number:
         return f"{numerator:.0f}/{denominator:.0f}"
 
-    return f"{whole_number:.0f} {numerator:.0f}/{denominator:.0f}"
+    # int() truncates toward zero, so for a negative number both
+    # whole_number and numerator carry the minus sign, which prints as
+    # "-1 -3/10". The sign already rides on the whole part; absorb it
+    # from the fractional part so the result reads as a normal mixed
+    # fraction.
+    return f"{whole_number:.0f} {abs(numerator):.0f}/{denominator:.0f}"
 
 
 def scientific(value: NumberOrString, precision: int = 2) -> str:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -183,6 +183,9 @@ def test_apnumber(test_input: int | str, expected: str) -> None:
         (-math.inf, "-Inf"),
         ("nan", "NaN"),
         ("-inf", "-Inf"),
+        (-1.3, "-1 3/10"),
+        (-2.5, "-2 1/2"),
+        (-0.5, "-1/2"),
     ],
 )
 def test_fractional(test_input: float | str, expected: str) -> None:


### PR DESCRIPTION
\`fractional(-1.3)\` currently returns \`'-1 -3/10'\`. Same shape for any negative number whose absolute value is at least 1: \`fractional(-2.5)\` returns \`'-2 -1/2'\`, etc.

\`int()\` truncates toward zero, so \`int(-1.3)\` is \`-1\` and \`-1.3 - (-1)\` is \`-0.3\`, which \`Fraction\` keeps as \`-3/10\`. Both the whole-number part and the numerator end up signed and the format string prints them both verbatim.

The minus sign already rides on the whole-number part, so absorb it from the numerator with \`abs()\`. The result is the conventional mixed-fraction form \`'-1 3/10'\` (= -1.3).

Added negative-input cases to \`test_fractional\`.