### PR TITLE
Fix typo in i18n.activate() docstring

### DIFF
--- a/src/humanize/i18n.py
+++ b/src/humanize/i18n.py
@@ -63,7 +63,7 @@ def activate(
 
     Args:
         locale (str | None): Language name, e.g. `en_GB`. If `None`, defaults to no
-            transaltion. Similar to calling ``deactivate()``.
+            translation. Similar to calling ``deactivate()``.
         path (str | pathlib.Path): Path to search for locales.
 
     Returns:


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix a spelling typo in the `activate()` docstring (`src/humanize/i18n.py`): "no transaltion" → "no translation".

This docstring is rendered in the published API documentation via mkdocstrings, so the typo was user-visible. No code behaviour changes.