### PR TITLE
Fix `naturalsize()` rounding rollover at unit boundaries

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -97,6 +97,12 @@ def naturalsize(
         return f"{int(bytes_)}B" if gnu else _("%d Bytes") % int(bytes_)
 
     exp = int(min(log(abs_bytes, base), len(suffix)))
+    # The suffix is chosen from the unrounded byte count, but `format` rounds the
+    # mantissa afterward; rounding can push it up to `base` (e.g. 999999 is
+    # 999.999 kB, which formats to "1000.0 kB"). When that happens and a larger
+    # suffix is available, step up one suffix so the result reads "1.0 MB".
+    if exp < len(suffix) and abs(float(format % (abs_bytes / (base**exp)))) >= base:
+        exp += 1
     space = "" if gnu else " "
     ret: str = format % (bytes_ / (base**exp)) + space + _(suffix[exp - 1])
     return ret

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -82,6 +82,15 @@ import humanize
         ([1.123456789, False, True], "1B"),
         ([1.123456789 * 10**3, False, True], "1.1K"),
         ([1.123456789 * 10**6, False, True], "1.1M"),
+        # Rounding must not leave the mantissa at the base while a larger suffix
+        # is available: 999999 is 999.999 kB, which the "%.1f" format rounds to
+        # 1000.0 and must carry into 1.0 MB rather than render as "1000.0 kB".
+        ([999999], "1.0 MB"),
+        ([999999999], "1.0 GB"),
+        ([999999999999], "1.0 TB"),
+        ([1024**2 - 1, True], "1.0 MiB"),
+        ([1024**3 - 1, True], "1.0 GiB"),
+        ([1024**2 - 1, False, True], "1.0M"),
     ],
 )
 def test_naturalsize(test_args: list[int] | list[int | bool], expected: str) -> None:


### PR DESCRIPTION
### Problem

`naturalsize()` picks the suffix from the **unrounded** byte count (`exp = int(min(log(abs_bytes, base), ...))`), then rounds the mantissa with the `format` string afterward. When rounding pushes the mantissa up to the base, the already-chosen suffix is left stale:

```pycon
>>> from humanize import naturalsize
>>> naturalsize(999999)
'1000.0 kB'      # expected '1.0 MB'
>>> naturalsize(999999999)
'1000.0 MB'      # expected '1.0 GB'
>>> naturalsize(1024 ** 2 - 1, binary=True)
'1024.0 KiB'     # expected '1.0 MiB'
```

`999999` bytes is `999.999 kB`; `"%.1f"` rounds that to `1000.0`, but the suffix was already fixed at `kB`, so the output reads `1000.0 kB` instead of `1.0 MB`. This happens at every decimal, binary, and GNU boundary.

This is **distinct** from the two related changes already in the repo:

- **#206** (closed #205) fixed the `ZB → YB` *top* boundary by adding larger suffixes (`RB`/`QB`); it never touched the rounding logic, so small-unit rollover remained.
- **#328** fixes the same class in `metric()` — a different function in `number.py`.

### Fix

After rounding, if the mantissa has reached the base (`1000` decimal / `1024` binary) **and** a larger suffix is available, step up one suffix. Values already at the largest suffix (`QB`/`QiB`) are unaffected (e.g. the documented `naturalsize(10**34 * 3)` → `'30000.0 QB'` still holds), as are all values that don't round across a boundary.

### Tests

Added regression assertions to `test_naturalsize` covering decimal, binary, and GNU boundaries. They fail on the current code and pass with this change; every existing assertion and documented example is unchanged (70 → 76 passing).
