### PR TITLE
Add Czech (cs_CZ) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ size or throughput. It is localized to:
 - Bengali
 - Brazilian Portuguese
 - Catalan
+- Czech
 - Danish
 - Dutch
 - Esperanto

--- a/src/humanize/locale/cs_CZ/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/cs_CZ/LC_MESSAGES/humanize.po
@@ -1,0 +1,354 @@
+# Czech translation of humanize
+# Copyright (C) 2026
+# This file is distributed under the same license as the humanize package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: humanize\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-23 09:28+0530\n"
+"PO-Revision-Date: 2026-06-23 09:30+0200\n"
+"Last-Translator: \n"
+"Language-Team: cs <LL@li.org>\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: src/humanize/number.py:84
+msgctxt "0 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:85
+msgctxt "1 (male)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:86
+msgctxt "2 (male)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:87
+msgctxt "3 (male)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:88
+msgctxt "4 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:89
+msgctxt "5 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:90
+msgctxt "6 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:91
+msgctxt "7 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:92
+msgctxt "8 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:93
+msgctxt "9 (male)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:97
+msgctxt "0 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:98
+msgctxt "1 (female)"
+msgid "st"
+msgstr "."
+
+#: src/humanize/number.py:99
+msgctxt "2 (female)"
+msgid "nd"
+msgstr "."
+
+#: src/humanize/number.py:100
+msgctxt "3 (female)"
+msgid "rd"
+msgstr "."
+
+#: src/humanize/number.py:101
+msgctxt "4 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:102
+msgctxt "5 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:103
+msgctxt "6 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:104
+msgctxt "7 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:105
+msgctxt "8 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/number.py:106
+msgctxt "9 (female)"
+msgid "th"
+msgstr "."
+
+#: src/humanize/filesize.py:94
+#, python-format
+msgid "%d Byte"
+msgstr "%d bajt"
+
+#: src/humanize/filesize.py:97
+#, python-format
+msgid "%d Bytes"
+msgstr "%d bajtů"
+
+#: src/humanize/number.py:179
+msgid "thousand"
+msgid_plural "thousand"
+msgstr[0] "tisíc"
+msgstr[1] "tisíc"
+msgstr[2] "tisíc"
+
+#: src/humanize/number.py:180
+msgid "million"
+msgid_plural "million"
+msgstr[0] "milion"
+msgstr[1] "miliony"
+msgstr[2] "milionů"
+
+#: src/humanize/number.py:181
+msgid "billion"
+msgid_plural "billion"
+msgstr[0] "miliarda"
+msgstr[1] "miliardy"
+msgstr[2] "miliard"
+
+#: src/humanize/number.py:182
+msgid "trillion"
+msgid_plural "trillion"
+msgstr[0] "bilion"
+msgstr[1] "biliony"
+msgstr[2] "bilionů"
+
+#: src/humanize/number.py:183
+msgid "quadrillion"
+msgid_plural "quadrillion"
+msgstr[0] "biliarda"
+msgstr[1] "biliardy"
+msgstr[2] "biliard"
+
+#: src/humanize/number.py:184
+msgid "quintillion"
+msgid_plural "quintillion"
+msgstr[0] "trilion"
+msgstr[1] "triliony"
+msgstr[2] "trilionů"
+
+#: src/humanize/number.py:185
+msgid "sextillion"
+msgid_plural "sextillion"
+msgstr[0] "triliarda"
+msgstr[1] "triliardy"
+msgstr[2] "triliard"
+
+#: src/humanize/number.py:186
+msgid "septillion"
+msgid_plural "septillion"
+msgstr[0] "kvadrilion"
+msgstr[1] "kvadriliony"
+msgstr[2] "kvadrilionů"
+
+#: src/humanize/number.py:187
+msgid "octillion"
+msgid_plural "octillion"
+msgstr[0] "kvadriliarda"
+msgstr[1] "kvadriliardy"
+msgstr[2] "kvadriliard"
+
+#: src/humanize/number.py:188
+msgid "nonillion"
+msgid_plural "nonillion"
+msgstr[0] "kvintilion"
+msgstr[1] "kvintiliony"
+msgstr[2] "kvintilionů"
+
+#: src/humanize/number.py:189
+msgid "decillion"
+msgid_plural "decillion"
+msgstr[0] "kvintiliarda"
+msgstr[1] "kvintiliardy"
+msgstr[2] "kvintiliard"
+
+#: src/humanize/number.py:190
+msgid "googol"
+msgid_plural "googol"
+msgstr[0] "googol"
+msgstr[1] "googoly"
+msgstr[2] "googolů"
+
+#: src/humanize/time.py:166
+#, python-format
+msgid "%d microsecond"
+msgid_plural "%d microseconds"
+msgstr[0] "%d mikrosekunda"
+msgstr[1] "%d mikrosekundy"
+msgstr[2] "%d mikrosekund"
+
+#: src/humanize/time.py:175
+#, python-format
+msgid "%d millisecond"
+msgid_plural "%d milliseconds"
+msgstr[0] "%d milisekunda"
+msgstr[1] "%d milisekundy"
+msgstr[2] "%d milisekund"
+
+#: src/humanize/time.py:178 src/humanize/time.py:294
+msgid "a moment"
+msgstr "okamžik"
+
+#: src/humanize/time.py:181
+msgid "a second"
+msgstr "sekunda"
+
+#: src/humanize/time.py:184
+#, python-format
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunda"
+msgstr[1] "%d sekundy"
+msgstr[2] "%d sekund"
+
+#: src/humanize/time.py:189
+msgid "a minute"
+msgstr "minuta"
+
+#: src/humanize/time.py:192 src/humanize/time.py:199
+msgid "an hour"
+msgstr "hodina"
+
+#: src/humanize/time.py:194
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuta"
+msgstr[1] "%d minuty"
+msgstr[2] "%d minut"
+
+#: src/humanize/time.py:202 src/humanize/time.py:208
+msgid "a day"
+msgstr "den"
+
+#: src/humanize/time.py:204
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d hodina"
+msgstr[1] "%d hodiny"
+msgstr[2] "%d hodin"
+
+#: src/humanize/time.py:211 src/humanize/time.py:214
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d den"
+msgstr[1] "%d dny"
+msgstr[2] "%d dní"
+
+#: src/humanize/time.py:217
+msgid "a month"
+msgstr "měsíc"
+
+#: src/humanize/time.py:220 src/humanize/time.py:226
+msgid "a year"
+msgstr "rok"
+
+#: src/humanize/time.py:222
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "%d měsíc"
+msgstr[1] "%d měsíce"
+msgstr[2] "%d měsíců"
+
+#: src/humanize/time.py:229 src/humanize/time.py:244
+#, python-format
+msgid "1 year, %d day"
+msgid_plural "1 year, %d days"
+msgstr[0] "1 rok, %d den"
+msgstr[1] "1 rok, %d dny"
+msgstr[2] "1 rok, %d dní"
+
+#: src/humanize/time.py:233
+msgid "1 year, 1 month"
+msgstr "1 rok, 1 měsíc"
+
+#: src/humanize/time.py:237 src/humanize/time.py:246
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] "%d rok"
+msgstr[1] "%d roky"
+msgstr[2] "%d let"
+
+#: src/humanize/time.py:240
+#, python-format
+msgid "1 year, %d month"
+msgid_plural "1 year, %d months"
+msgstr[0] "1 rok, %d měsíc"
+msgstr[1] "1 rok, %d měsíce"
+msgstr[2] "1 rok, %d měsíců"
+
+#: src/humanize/time.py:291
+#, python-format
+msgid "%s from now"
+msgstr "za %s"
+
+#: src/humanize/time.py:291
+#, python-format
+msgid "%s ago"
+msgstr "před %s"
+
+#: src/humanize/time.py:295
+msgid "now"
+msgstr "nyní"
+
+#: src/humanize/time.py:341
+msgid "today"
+msgstr "dnes"
+
+#: src/humanize/time.py:344
+msgid "tomorrow"
+msgstr "zítra"
+
+#: src/humanize/time.py:347
+msgid "yesterday"
+msgstr "včera"
+
+#: src/humanize/time.py:669
+#, python-format
+msgid "%s and %s"
+msgstr "%s a %s"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -117,6 +117,12 @@ def test_naturaldelta() -> None:
         ("lv", 2_000_000, "2,0 miljoni"),
         ("lv", 11_000_000, "11,0 miljoni"),
         ("lv", 21_000_000, "21,0 miljons"),
+        # Czech uses dot as decimal separator
+        ("cs_CZ", 1_000_000, "1.0 milion"),
+        ("cs_CZ", 1_200_000, "1.2 miliony"),
+        ("cs_CZ", 1_000_000_000, "1.0 miliarda"),
+        ("cs_CZ", 3_500_000_000, "3.5 miliardy"),
+        ("cs_CZ", 1_000_000_000_000, "1.0 bilion"),
         ("fr_FR", "1_000", "1.0 mille"),
         ("fr_FR", "12_400", "12.4 milles"),
         ("fr_FR", "12_490", "12.5 milles"),
@@ -180,6 +186,8 @@ def test_intword_i18n(locale: str, number: int, expected_result: str) -> None:
         ("fr_FR", 42_000_000, "42.0 Mo"),
         ("fr_FR", 42_000_000_000, "42.0 Go"),
         ("fr_FR", -42_000, "-42.0 Ko"),
+        ("cs_CZ", 1, "1 bajt"),
+        ("cs_CZ", 42, "42 bajtů"),
     ],
 )
 def test_naturalsize_i18n(locale: str, value: float, expected_result: str) -> None:


### PR DESCRIPTION
## Add Czech (`cs_CZ`) locale

This adds a complete Czech translation catalog for humanize.

### What's translated
- **Filesize** strings (`%d Byte` / `%d Bytes` → `bajt` / `bajtů`)
- **Large-number scale words** for `intword` using long-scale Czech naming: `milion`, `miliarda`, `bilion`, `biliarda`, `trilion`, `triliarda`, `kvadrilion`, ... down to `googol`
- **Relative time** phrases for `naturaltime` / `naturaldelta` (`před %s` / `za %s`, `nyní`, `dnes`, `zítra`, `včera`, plus all second/minute/hour/day/month/year units)
- **Ordinals** (`ordinal`) — Czech ordinals are written with a trailing period (e.g. `5.`)

### Plural forms
Czech has three plural categories (one / few / many). The catalog declares the standard rule:

```
Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;
```

and provides `msgstr[0..2]` for every plural message (matching the existing Slovak `sk_SK` catalog, a closely related language).

### How it was produced
The template was regenerated from the current sources with the documented workflow (`xgettext` with the project's keyword set), the catalog initialised with `msginit --locale cs_CZ`, then every `msgstr` translated by hand. `msgfmt --check` reports **59 translated, 0 fuzzy, 0 untranslated** and validates all format strings and plural counts.

### Tests
- Added `cs_CZ` cases to the parametrized `test_intword_i18n` and `test_naturalsize_i18n` tests in `tests/test_i18n.py`.
- Listed Czech in the README locale list, as the contributing docs request.
- Full suite passes locally: `777 passed`. `ruff check` clean.

Only the `.po` source is committed; `.mo` binaries remain gitignored and are produced by `scripts/generate-translation-binaries.sh`, matching every other locale.
