### PR TITLE
Support Romanian ordinal formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ size or throughput. It is localized to:
 - Norwegian
 - Persian
 - Polish
+- Romanian
 - Russian
 - Simplified Chinese
 - Slovak

--- a/src/humanize/locale/ro/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ro/LC_MESSAGES/humanize.po
@@ -1,0 +1,126 @@
+# Romanian translations for humanize.
+# This file is distributed under the same license as the humanize package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: humanize\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-24 00:00+0000\n"
+"PO-Revision-Date: 2026-06-24 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Romanian\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);\n"
+
+#: src/humanize/number.py
+msgctxt "ordinal value 1 (male)"
+msgid "%(value)s"
+msgstr "primul"
+
+#: src/humanize/number.py
+msgctxt "ordinal value 1 (female)"
+msgid "%(value)s"
+msgstr "prima"
+
+#: src/humanize/number.py
+msgctxt "ordinal 0 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 1 (male)"
+msgid "%(value)sst"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 2 (male)"
+msgid "%(value)snd"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 3 (male)"
+msgid "%(value)srd"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 4 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 5 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 6 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 7 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 8 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 9 (male)"
+msgid "%(value)sth"
+msgstr "al %(value)s-lea"
+
+#: src/humanize/number.py
+msgctxt "ordinal 0 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 1 (female)"
+msgid "%(value)sst"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 2 (female)"
+msgid "%(value)snd"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 3 (female)"
+msgid "%(value)srd"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 4 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 5 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 6 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 7 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 8 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"
+
+#: src/humanize/number.py
+msgctxt "ordinal 9 (female)"
+msgid "%(value)sth"
+msgstr "a %(value)s-a"

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -34,6 +34,7 @@ _SUPERSCRIPT_MAP = {
 _SUPERSCRIPT_TRANS = str.maketrans(_SUPERSCRIPT_MAP)
 
 _ORDINAL_SUFFIXES = ("th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th")
+_ORDINAL_VALUE = "%(value)s"
 _APNUMBER_WORDS = (
     "zero",
     "one",
@@ -108,7 +109,11 @@ def ordinal(value: NumberOrString, gender: str = "male") -> str:
         return str(value)
     gender = "male" if gender == "male" else "female"
     digit = 0 if value % 100 in (11, 12, 13) else value % 10
-    return f"{value}{P_(f'{digit} ({gender})', _ORDINAL_SUFFIXES[digit])}"
+    ordinal_format = P_(f"ordinal value {value} ({gender})", _ORDINAL_VALUE)
+    if ordinal_format == _ORDINAL_VALUE:
+        suffix = P_(f"{digit} ({gender})", _ORDINAL_SUFFIXES[digit])
+        ordinal_format = P_(f"ordinal {digit} ({gender})", f"{_ORDINAL_VALUE}{suffix}")
+    return ordinal_format % {"value": value}
 
 
 def intcomma(value: NumberOrString, ndigits: int | None = None) -> str:

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -237,6 +237,12 @@ def test_langauge_codes(locale: str, expected_result: str) -> None:
         ("es_ES", 5, "female", "5ª"),
         ("it_IT", 3, "male", "3º"),
         ("it_IT", 8, "female", "8ª"),
+        ("ro", 1, "male", "primul"),
+        ("ro", 1, "female", "prima"),
+        ("ro", 2, "male", "al 2-lea"),
+        ("ro", 2, "female", "a 2-a"),
+        ("ro", 21, "male", "al 21-lea"),
+        ("ro", 23, "female", "a 23-a"),
     ],
 )
 def test_ordinal_genders(


### PR DESCRIPTION
Fixes #270

Changes proposed in this pull request:

* Allow ordinal translations to provide a complete value-aware format while preserving the existing suffix-only fallback.
* Add Romanian ordinal translations for male and female forms, including the special `1` forms and numeric forms such as `21`/`23`.
* Add regression coverage for Romanian ordinal output.

Validation:

* `bash scripts/generate-translation-binaries.sh`
* `python -m pytest -q` (`776 passed`)
* `python -m ruff check .`
* `python -m ruff format --check .`