### PR TITLE
fix: handle decimal string input in intword()

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -231,7 +231,7 @@ def intword(value: NumberOrString, format: str = "%.1f") -> str:
     try:
         if not math.isfinite(float(value)):
             return _format_not_finite(float(value))
-        value = int(value)
+        value = int(float(value))
     except (TypeError, ValueError):
         return str(value)
 


### PR DESCRIPTION
Bug: intword("12400.9") returns "12400.9" instead of "12.4 thousand" because int("12400.9") raises a ValueError in Python.
Fix: Changed value = int(value) to value = int(float(value)) so decimal strings are handled correctly, consistent with how intcomma() already handles this case.
