### PR TITLE
Lazy imports for Python 3.15+

### DIFF
--- a/src/humanize/__init__.py
+++ b/src/humanize/__init__.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "humanize._version",
+    "humanize.filesize",
+    "humanize.i18n",
+    "humanize.lists",
+    "humanize.number",
+    "humanize.time",
+}
+
 from humanize.filesize import naturalsize
 from humanize.i18n import activate, deactivate, decimal_separator, thousands_separator
 from humanize.lists import natural_list

--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"humanize.i18n", "math"}
+
 from math import log
 
 from humanize.i18n import _gettext as _

--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"bisect"}
+
 import bisect
 
 from .i18n import _gettext as _

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -5,6 +5,8 @@ These are largely borrowed from Django's `contrib.humanize`.
 
 from __future__ import annotations
 
+__lazy_modules__ = {"humanize.i18n", "humanize.number"}
+
 from enum import Enum
 from functools import total_ordering
 


### PR DESCRIPTION
<table>
<tr>
<th>Before: 5 ms
<th>After: ~0 ms
<tr>
<td valign="top">
<img width="2405" height="1696" alt="image" src="https://github.com/user-attachments/assets/c2e3af06-0d2a-45dd-8905-cdb940d70bab" />

<td valign="top">
<img width="2405" height="1090" alt="image" src="https://github.com/user-attachments/assets/0188f0ca-9540-4801-bd7a-2a31f900f10f" />

</table>