### PR TITLE
Fix `intword()` rounding carry for very large numbers

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -255,8 +255,12 @@ def intword(value: NumberOrString, format: str = "%.1f") -> str:
     chopped = value / power
     rounded_value = float(format % chopped)
 
-    if not largest_ordinal and rounded_value * power == powers[ordinal + 1]:
-        # After rounding, we end up just at the next power
+    if not largest_ordinal and rounded_value == powers[ordinal + 1] // power:
+        # After rounding, we end up just at the next power. Compare against the
+        # integer ratio between the two powers instead of ``rounded_value * power``:
+        # for values above ~10**22 the latter is evaluated in floating point and
+        # no longer equals the exact ``powers[ordinal + 1]``, so the carry was
+        # silently skipped (e.g. 10**24 - 1 rendered as "1000.0 sextillion").
         ordinal += 1
         rounded_value = 1.0
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -141,6 +141,47 @@ def test_intword(test_args: list[str], expected: str) -> None:
     assert humanize.intword(*test_args) == expected
 
 
+def test_intword_rounding_rollover() -> None:
+    """Values that round up to the next power must carry to the next unit.
+
+    Regression: for magnitudes above ~10**22 the carry was checked in floating
+    point (``rounded_value * power == powers[ordinal + 1]``) and no longer
+    matched the exact integer power, so e.g. ``10**24 - 1`` was rendered as
+    "1000.0 sextillion" instead of "1.0 septillion".
+    """
+    units = [
+        "thousand",
+        "million",
+        "billion",
+        "trillion",
+        "quadrillion",
+        "quintillion",
+        "sextillion",
+        "septillion",
+        "octillion",
+        "nonillion",
+        "decillion",
+    ]
+    # value = 10**e - 1 rounds up to 10**e with "%.1f"/"%.0f", i.e. exactly 1.0
+    # of the unit sitting at 10**e (units[i] where 10**e == powers[i]).
+    for i, exponent in enumerate(range(6, 34, 3), start=1):
+        value = 10**exponent - 1
+        assert humanize.intword(value) == f"1.0 {units[i]}"
+        assert humanize.intword(value, "%.0f") == f"1 {units[i]}"
+
+    # The mantissa must never render at or above 1000 for values below a
+    # decillion; a bare "1000.0" is only expected in the sparse gap between
+    # decillion and googol, which has no dedicated unit.
+    for exponent in range(6, 34, 3):
+        rendered = humanize.intword(10**exponent - 1)
+        mantissa = float(rendered.split(" ", 1)[0])
+        assert mantissa < 1000
+
+    # The documented decillion..googol gap must be left untouched.
+    assert humanize.intword(10**36) == "1000.0 decillion"
+    assert humanize.intword(2 * 10**100) == "2.0 googol"
+
+
 @pytest.mark.parametrize(
     "test_input, expected",
     [


### PR DESCRIPTION
### Problem

`intword()` decides whether rounding pushed a value up into the next magnitude
with:

```python
if not largest_ordinal and rounded_value * power == powers[ordinal + 1]:
```

For values above ~`10**22`, `rounded_value * power` is evaluated in floating
point and no longer equals the exact `powers[ordinal + 1]`, so the carry is
skipped and the number is rendered against the *lower* magnitude:

```python
>>> import humanize
>>> humanize.intword(10**24 - 1)
'1000.0 sextillion'      # expected '1.0 septillion'
>>> humanize.intword(10**27 - 1)
'1000.0 septillion'      # expected '1.0 octillion'
```

The same happens at `10**30` and `10**33`.

### Fix

Compare `rounded_value` against the exact integer ratio
`powers[ordinal + 1] // power`, keeping the check in exact integer terms rather
than relying on a large float product. This mirrors the recently fixed carry
handling in `metric()` (#328) and `naturalsize()` (#329).

### Tests

`test_intword_rounding_rollover` asserts the correct roll-over across every
affected magnitude (`10**24/27/30/33 - 1`), plus a couple of just-below cases
that must *not* roll over, guarding both directions.

`pytest` → 716 passed. `ruff check` / `ruff format --check` clean.
