### PR TITLE
fix: avoid OverflowError in naturaltime for far-future dates

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -61,9 +61,9 @@ def _abs_timedelta(delta: dt.timedelta) -> dt.timedelta:
     Returns:
         datetime.timedelta: Absolute timedelta.
     """
+    # Avoid datetime arithmetic: now+(now-far_future) underflows below year 1.
     if delta.days < 0:
-        now = _now()
-        return now - (now + delta)
+        return -delta
     return delta
 
 
@@ -82,14 +82,18 @@ def _date_and_delta(
         date = value
         delta = now - value
     elif isinstance(value, dt.timedelta):
-        date = now - value
         delta = value
+        try:
+            date = now - value
+        except OverflowError:
+            # Tense only: negative timedelta means future in naturaltime.
+            date = now + dt.timedelta(days=1) if value < dt.timedelta(0) else now - dt.timedelta(days=1)
     else:
         try:
             value = value if precise else round(value)
             delta = dt.timedelta(seconds=value)
             date = now - delta
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return None, value
     return date, _abs_timedelta(delta)
 

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -82,18 +82,14 @@ def _date_and_delta(
         date = value
         delta = now - value
     elif isinstance(value, dt.timedelta):
+        date = now - value
         delta = value
-        try:
-            date = now - value
-        except OverflowError:
-            # Tense only: negative timedelta means future in naturaltime.
-            date = now + dt.timedelta(days=1) if value < dt.timedelta(0) else now - dt.timedelta(days=1)
     else:
         try:
             value = value if precise else round(value)
             delta = dt.timedelta(seconds=value)
             date = now - delta
-        except (ValueError, TypeError, OverflowError):
+        except (ValueError, TypeError):
             return None, value
     return date, _abs_timedelta(delta)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -179,6 +179,10 @@ def test_naturaldelta(test_input: float | dt.timedelta, expected: str) -> None:
         (NOW - dt.timedelta(days=365 * 2 + 65), "2 years ago"),
         (NOW - dt.timedelta(days=365 + 4), "1 year, 4 days ago"),
         ("NaN", "NaN"),
+        # Far-future datetimes used to OverflowError in _abs_timedelta.
+        (dt.datetime(9999, 1, 1), "7,994 years from now"),
+        (dt.datetime(5000, 6, 15), "2,992 years from now"),
+        (dt.timedelta(days=-1_000_000), "2,739 years from now"),
     ],
 )
 def test_naturaltime(


### PR DESCRIPTION
humanize.time._abs_timedelta hits OverflowError when naturaltime far-future datetime underflows via now+delta. This PR fixes the regression with a focused test covering the case.
