### PR TITLE
Fix `fractional()` emitting degenerate output when the fraction rounds to a whole

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -361,10 +361,12 @@ def fractional(value: NumberOrString) -> str:
     frac = Fraction(number - whole_number).limit_denominator(1000)
     numerator = frac.numerator
     denominator = frac.denominator
-    if whole_number and not numerator and denominator == 1:
-        # this means that an integer was passed in
-        # (or variants of that integer like 1.0000)
-        return f"{whole_number:.0f}"
+    if denominator == 1:
+        # The fractional part reduced to a whole number: either an integer
+        # was passed in (e.g. 1 or 1.0000, giving 0/1), or the fractional part
+        # rounded up to 1/1 (e.g. 2.9999999). Fold it into the integer part
+        # instead of emitting a degenerate "0/1" or "2 1/1".
+        return f"{whole_number + numerator:.0f}"
 
     if not whole_number:
         return f"{numerator:.0f}/{denominator:.0f}"

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -187,6 +187,11 @@ def test_apnumber(test_input: int | str, expected: str) -> None:
         (-1.3, "-1 3/10"),
         (-2.5, "-2 1/2"),
         (-0.5, "-1/2"),
+        (0, "0"),
+        (0.0, "0"),
+        (2.9999999, "3"),
+        (0.9999999, "1"),
+        (-2.9999999, "-3"),
     ],
 )
 def test_fractional(test_input: float | str, expected: str) -> None:


### PR DESCRIPTION
Noticed while probing edge cases: `fractional()` emits degenerate output when the fractional part rounds to a whole number.

```pycon
>>> import humanize
>>> humanize.fractional(2.9999999)
'2 1/1'        # expected '3'
>>> humanize.fractional(0.9999999)
'1/1'          # expected '1'
>>> humanize.fractional(0)
'0/1'          # expected '0'
```

### Cause

After `frac = Fraction(number - whole_number).limit_denominator(1000)`, when the fractional part reduces to a whole number the denominator is `1` (numerator ∈ {-1, 0, 1}). The existing special case only handled `numerator == 0` (a plain integer input like `1.0`), so:

* `numerator == 1` (the fraction rounded up to `1/1`) fell through to the mixed-fraction branch → `"2 1/1"`;
* `fractional(0)` produced `"0/1"`.

Changes proposed in this pull request:

* Fold any whole-valued fractional part (`denominator == 1`) into the integer part, so the result reads as a normal integer.
* Add regression tests for `0`, `0.0`, `2.9999999`, `0.9999999`, `-2.9999999`.

All existing tests pass (`705 passed`); `ruff` and `black` clean.