### PR TITLE
fix: catch OverflowError in naturalsize() for very large integers

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -89,7 +89,12 @@ def naturalsize(
         suffix = suffixes["decimal"]
 
     base = 1024 if (gnu or binary) else 1000
-    bytes_ = float(value)
+    try:
+        bytes_ = float(value)
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"naturalsize() argument must be a number, not {type(value).__name__!r}"
+        ) from exc
     abs_bytes = abs(bytes_)
 
     if abs_bytes == 1 and not gnu:


### PR DESCRIPTION
## Problem

`naturalsize()` calls `float(value)` unconditionally, which raises `OverflowError` for very large integers:

```python
>>> import humanize
>>> humanize.naturalsize(10**309)
OverflowError: int too large to convert to float
```

It also raises a raw `ValueError` from `float()` for non-numeric strings, with a confusing message.

## Fix

Wrap `float(value)` in `try/except (ValueError, OverflowError)` and re-raise with a clear message indicating the argument type.

## After fix

```python
>>> humanize.naturalsize(10**309)
ValueError: naturalsize() argument must be a number, not 'int'
>>> humanize.naturalsize("abc")
ValueError: naturalsize() argument must be a number, not 'str'
```