### PR TITLE
Fix `metric()` showing an extra significant digit on rounding carry

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -548,8 +548,13 @@ def metric(value: float, unit: str = "", precision: int = 3) -> str:
     old_bucket = exponent // 3 * 3
     value /= 10**old_bucket
     digits = int(max(0, precision - exponent % 3 - 1))
-    if exponent < 30 and round(abs(value), digits) >= 1000:
-        exponent += 3 - exponent % 3
+    # Rounding to ``digits`` decimal places can carry the mantissa up to the
+    # next power of ten (e.g. 9.999 -> 10.0, 99.99 -> 100, 999.9 -> 1000),
+    # which adds an integer digit and would otherwise show one significant
+    # figure too many. Bump the exponent to absorb the carry -- crossing into
+    # the next SI bucket when the mantissa reaches 1000 -- and recompute.
+    if exponent < 30 and round(abs(value), digits) >= 10 ** (exponent % 3 + 1):
+        exponent += 1
         new_bucket = exponent // 3 * 3
         value /= 10 ** (new_bucket - old_bucket)
         digits = int(max(0, precision - exponent % 3 - 1))

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -258,6 +258,15 @@ def test_clamp(test_args: list[typing.Any], expected: str) -> None:
         ([1234.56], "1.23 k"),
         ([12345, "", 6], "12.3450 k"),
         ([200_000], "200 k"),
+        # Rounding that carries the mantissa up a power of ten within a
+        # bucket must not add an extra significant figure (issue: metric
+        # showed one digit too many for e.g. 9999 -> "10.00 k").
+        ([9999], "10.0 k"),
+        ([99999], "100 k"),
+        ([9.99999], "10.0"),
+        ([-9999], "-10.0 k"),
+        ([9.999, "", 2], "10"),
+        ([999.4], "999"),
         ([999.9, "V"], "1.00 kV"),
         ([999.99, "V"], "1.00 kV"),
         ([999_999, "V"], "1.00 MV"),


### PR DESCRIPTION
### Summary

`metric()` can show one significant figure too many when rounding carries the mantissa up a power of ten.

```pycon
>>> import humanize
>>> humanize.metric(9999)
'10.00 k'      # 4 significant figures at the default precision=3
>>> humanize.metric(99999)
'100.0 k'      # 4 significant figures
>>> humanize.metric(9.99999)
'10.00'
```

The neighbours prove the inconsistency — same magnitude, correct 3 significant figures:

```pycon
>>> humanize.metric(10000)
'10.0 k'
>>> humanize.metric(100000)
'100 k'
```

### Cause

The number of decimal places is derived from the mantissa's position in its SI bucket (`digits = precision - exponent % 3 - 1`), which assumes the mantissa keeps its integer-digit count. When rounding to `digits` places carries the mantissa up a power of ten (`9.999 → 10.0`, `99.99 → 100`), it gains an integer digit and therefore shows an extra significant figure.

The existing guard only handled the mantissa rounding all the way to `1000` (a full bucket crossing, e.g. `999.9 → 1.00 k`); it never handled the `→ 10` and `→ 100` crossings inside a bucket.

### Fix

Compare the rounded mantissa against the next power of ten (`10 ** (exponent % 3 + 1)`) rather than the hard-coded `1000`, and bump the exponent by one to absorb the carry. When the mantissa reaches `1000` this still crosses into the next SI bucket exactly as before, so all existing outputs (including `metric(999.9, "V") == "1.00 kV"`) are unchanged.

This matches the documented contract that the prefix is chosen "so that non-significant zero digits are required" and that `precision` is "the number of digits the output should contain."

Test cases for the within-bucket carry are added to `test_metric`; the full suite passes.
