### PR TITLE
Let ordinal translations interpolate the number (#270)

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -110,7 +110,14 @@ def ordinal(value: NumberOrString, gender: str = "male") -> str:
         return str(value)
     gender = "male" if gender == "male" else "female"
     digit = 0 if value % 100 in (11, 12, 13) else value % 10
-    return f"{value}{P_(f'{digit} ({gender})', _ORDINAL_SUFFIXES[digit])}"
+    suffix = P_(f"{digit} ({gender})", _ORDINAL_SUFFIXES[digit])
+    # Most languages append a suffix to the number ("2nd"), but some position the
+    # number inside the ordinal word (e.g. Romanian "al 2-lea", "a 2-a"). A
+    # translation can opt into that by including a "%s"/"%d" placeholder for the
+    # number; without one, the classic "<number><suffix>" form is kept.
+    if "%s" in suffix or "%d" in suffix:
+        return suffix % value
+    return f"{value}{suffix}"
 
 
 def intcomma(value: NumberOrString, ndigits: int | None = None) -> str:

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -252,6 +252,36 @@ def test_ordinal_genders(
         humanize.i18n.deactivate()
 
 
+def test_ordinal_interpolated_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ordinals whose translation carries a placeholder position the number
+    themselves, e.g. Romanian "al 2-lea" / "a 2-a". Regression test for #270.
+    """
+    from humanize import number
+
+    def fake_pgettext(msgctxt: str, message: str) -> str:
+        return "a %s-a" if "female" in msgctxt else "al %s-lea"
+
+    monkeypatch.setattr(number, "P_", fake_pgettext)
+    assert humanize.ordinal(2) == "al 2-lea"
+    assert humanize.ordinal(23) == "al 23-lea"
+    assert humanize.ordinal(2, gender="female") == "a 2-a"
+
+    # A %d placeholder is accepted as well.
+    monkeypatch.setattr(number, "P_", lambda ctx, msg: "%d-lea")
+    assert humanize.ordinal(7) == "7-lea"
+
+
+def test_ordinal_suffix_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A translation without a placeholder keeps the classic <number><suffix>
+    form, so existing locales are unaffected by the interpolation support.
+    """
+    from humanize import number
+
+    monkeypatch.setattr(number, "P_", lambda ctx, msg: "º")
+    assert humanize.ordinal(5) == "5º"
+    assert humanize.ordinal(21) == "21º"
+
+
 def test_default_locale_path_defined__spec__() -> None:
     i18n = importlib.import_module("humanize.i18n")
     assert i18n._get_default_locale_path() is not None


### PR DESCRIPTION
Fixes #270

`ordinal()` builds its result as `f"{value}{suffix}"`, so a translation can only ever supply a *trailing* suffix. As reported in #270, that makes languages whose ordinals place the number *inside* the word impossible to translate — e.g. Romanian `al 2-lea` (m) / `a 2-a` (f), where the number sits between a prefix and a suffix.

Changes proposed in this pull request:

* In `ordinal()`, if the (context-aware) translated string contains a `%s`/`%d` placeholder, format the number into it (`suffix % value`) so the translation controls where the number goes; otherwise keep the existing `"<number><suffix>"` behaviour.
* Add regression tests for both the interpolated path (Romanian-style `al 2-lea` / `a 2-a`, plus a `%d` variant) and the unchanged suffix path.

Backward compatibility:

* All 35 existing locales store bare suffixes (`"nd" -> "e"`, `"th" -> "º"`, …) with **no** placeholder, so they take the unchanged branch and their output is identical. The English default is unaffected (`ordinal(2) == "2nd"`). No `msgid` changes, so no existing translation needs re-merging.

Verified with a throwaway Romanian locale loaded through the real gettext path (`activate("ro", path=...)`):

```pycon
>>> humanize.ordinal(2)                  # al %s-lea
'al 2-lea'
>>> humanize.ordinal(23)                 # al %s-lea
'al 23-lea'
>>> humanize.ordinal(2, gender="female") # a %s-a
'a 2-a'
>>> humanize.i18n.deactivate()
>>> humanize.ordinal(2)
'2nd'
```

Full local run: `786 passed`, `ruff`/`black` clean.
