### PR TITLE
Fix fractional() formatting 0 as "0/1" instead of "0"

### DIFF
--- a/src/humanize/number.py
+++ b/src/humanize/number.py
@@ -361,9 +361,9 @@ def fractional(value: NumberOrString) -> str:
     frac = Fraction(number - whole_number).limit_denominator(1000)
     numerator = frac.numerator
     denominator = frac.denominator
-    if whole_number and not numerator and denominator == 1:
-        # this means that an integer was passed in
-        # (or variants of that integer like 1.0000)
+    if not numerator:
+        # no fractional part remains, so an integer was passed in
+        # (including 0, or variants of an integer like 1.0000)
         return f"{whole_number:.0f}"
 
     if not whole_number:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -187,6 +187,9 @@ def test_apnumber(test_input: int | str, expected: str) -> None:
         (-1.3, "-1 3/10"),
         (-2.5, "-2 1/2"),
         (-0.5, "-1/2"),
+        (0, "0"),
+        (0.0, "0"),
+        ("0", "0"),
     ],
 )
 def test_fractional(test_input: float | str, expected: str) -> None:


### PR DESCRIPTION
### Bug

`fractional(0)` returns `"0/1"`, while every other whole number returns a bare number:

```pycon
>>> import humanize
>>> humanize.fractional(0)
'0/1'      # expected '0'
>>> humanize.fractional(1)
'1'
>>> humanize.fractional(2)
'2'
>>> humanize.fractional(-2)
'-2'
```

### Cause

The whole-number branch is gated on `whole_number` being truthy:

```python
if whole_number and not numerator and denominator == 1:
    return f"{whole_number:.0f}"
```

`whole_number` is `0` (falsy) for the value `0`, so it falls through to the `if not whole_number:` branch and is rendered as `numerator/denominator` = `0/1`.

### Fix

The branch only needs to check that no fractional part remains, i.e. `numerator == 0`, which is true for any whole number including `0`. When the numerator is `0` the fraction is always `0/1`, so the `denominator == 1` check was redundant and is dropped.

Verified against all existing `test_fractional` cases (no changes) plus new cases for `0`, `0.0` and `"0"`.
