### PR TITLE
fix: catch OverflowError for non-finite floats in time functions

### DIFF
--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -146,7 +146,9 @@ def naturaldelta(
         delta = value
     else:
         try:
-            int(value)  # Force numeric types; strings like "NaN"/"inf" are returned unchanged
+            int(
+                value
+            )  # Force numeric types; strings like "NaN"/"inf" are returned unchanged
             value = float(value)
             delta = dt.timedelta(seconds=value)
         except (ValueError, TypeError, OverflowError):

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -146,7 +146,7 @@ def naturaldelta(
         delta = value
     else:
         try:
-            int(value)  # Explicitly don't support string such as "NaN" or "inf"
+            int(value)  # Force numeric types; strings like "NaN"/"inf" are returned unchanged
             value = float(value)
             delta = dt.timedelta(seconds=value)
         except (ValueError, TypeError, OverflowError):

--- a/src/humanize/time.py
+++ b/src/humanize/time.py
@@ -89,7 +89,7 @@ def _date_and_delta(
             value = value if precise else round(value)
             delta = dt.timedelta(seconds=value)
             date = now - delta
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return None, value
     return date, _abs_timedelta(delta)
 
@@ -114,11 +114,9 @@ def naturaldelta(
     Returns:
         str (str or `value`): A natural representation of the amount of time
             elapsed unless `value` is not datetime.timedelta or cannot be
-            converted to int (cannot be float due to 'inf' or 'nan').
-            In that case, a `value` is returned unchanged.
-
-    Raises:
-        OverflowError: If `value` is too large to convert to datetime.timedelta.
+            converted to int (cannot be float due to 'inf' or 'nan', or too
+            large to fit in a `datetime.timedelta`). In that case, `value` is
+            returned unchanged (via `str()`).
 
     Examples:
         Compare two timestamps in a custom local timezone::
@@ -151,7 +149,7 @@ def naturaldelta(
             int(value)  # Explicitly don't support string such as "NaN" or "inf"
             value = float(value)
             delta = dt.timedelta(seconds=value)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return str(value)
 
     use_months = months

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -838,6 +838,45 @@ def test_time_unit() -> None:
 
 
 @pytest.mark.parametrize(
+    "value, expected",
+    [
+        (float("inf"), "inf"),
+        (float("-inf"), "-inf"),
+        (float("nan"), "nan"),
+    ],
+)
+def test_naturaldelta_non_finite(value: float, expected: str) -> None:
+    # Regression test for #333: non-finite floats used to raise an uncaught
+    # OverflowError (or, for nan, were only handled when passed as a string)
+    # instead of being returned unchanged like other non-numeric input.
+    assert humanize.naturaldelta(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (float("inf"), "inf"),
+        (float("-inf"), "-inf"),
+        (float("nan"), "nan"),
+    ],
+)
+def test_naturaltime_non_finite(value: float, expected: str) -> None:
+    assert humanize.naturaltime(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (float("inf"), "inf"),
+        (float("-inf"), "-inf"),
+        (float("nan"), "nan"),
+    ],
+)
+def test_precisedelta_non_finite(value: float, expected: str) -> None:
+    assert humanize.precisedelta(value) == expected
+
+
+@pytest.mark.parametrize(
     "fmt, value, expected",
     [
         ("%.2f", 1.011, 1.01),


### PR DESCRIPTION
## Summary

Fixes #333.

`naturaldelta()`, `naturaltime()`, and `precisedelta()` all raise an uncaught `OverflowError` for `float('inf')` / `float('-inf')` instead of returning the value unchanged — inconsistent with every other numeric humanize function (`ordinal`, `intcomma`, `intword`, etc.), which already treat non-finite input this way, and inconsistent with how these same three functions already handle `float('nan')`.

```pycon
>>> import humanize
>>> humanize.naturaldelta(float("inf"))
Traceback (most recent call last):
    ...
OverflowError: cannot convert float infinity to integer
```

**Root cause:** `int()` / `round()` raise `OverflowError` (not `ValueError` or `TypeError`) for infinite floats. That exception wasn't included in the `except` clauses guarding the `timedelta` conversion in `naturaldelta()`, nor in the shared `_date_and_delta()` helper used by `naturaltime()` and `precisedelta()`. Since both call sites share the same root cause, this fixes all three functions rather than just the one named in the issue.

## Changes

- `src/humanize/time.py`: add `OverflowError` to the two relevant `except` clauses (in `naturaldelta()` and `_date_and_delta()`).
- Updated `naturaldelta()`'s docstring, which documented the crash as a `Raises: OverflowError` — that was describing the bug, not an intentional design.
- Added regression tests for `inf`/`-inf`/`nan` across `naturaldelta`, `naturaltime`, and `precisedelta`.

## Test plan

- [x] `pytest tests/test_time.py -q` — 392 passed
- [x] Full suite: `pytest -q` — 724 passed, 74 skipped, 0 failed
- [x] `ruff check` on changed files — clean
- [x] Manually verified `naturaldelta`/`naturaltime`/`precisedelta` no longer raise for `inf`/`-inf`, and behavior for genuinely-too-large-but-finite values (e.g. `1e300`) is now consistent (returned unchanged rather than raising)