### PR TITLE
Remove the leftover format placeholder from `intword` units

### DIFF
--- a/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/bn_BD/LC_MESSAGES/humanize.po
@@ -121,57 +121,57 @@ msgstr "তম"
 #: src/humanize/number.py:178
 msgid "thousand"
 msgid_plural "thousand"
-msgstr[0] "%d হাজার"
-msgstr[1] "%d হাজার"
+msgstr[0] "হাজার"
+msgstr[1] "হাজার"
 
 #: src/humanize/number.py:179
 #, fuzzy
 msgid "million"
 msgid_plural "million"
-msgstr[0] "%d মিলিয়ন"
-msgstr[1] "%d মিলিয়ন"
+msgstr[0] "মিলিয়ন"
+msgstr[1] "মিলিয়ন"
 
 #: src/humanize/number.py:180
 msgid "billion"
 msgid_plural "billion"
-msgstr[0] "%d বিলিয়ন"
-msgstr[1] "%d বিলিয়ন"
+msgstr[0] "বিলিয়ন"
+msgstr[1] "বিলিয়ন"
 
 #: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
-msgstr[0] "%d ট্রিলিয়ন"
-msgstr[1] "%d ট্রিলিয়ন"
+msgstr[0] "ট্রিলিয়ন"
+msgstr[1] "ট্রিলিয়ন"
 
 #: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
-msgstr[0] "%d কোয়াড্রিলিয়ন"
-msgstr[1] "%d কোয়াড্রিলিয়ন"
+msgstr[0] "কোয়াড্রিলিয়ন"
+msgstr[1] "কোয়াড্রিলিয়ন"
 
 #: src/humanize/number.py:183
 msgid "quintillion"
 msgid_plural "quintillion"
-msgstr[0] "%d কুইন্টিলিয়ন"
-msgstr[1] "%d কুইন্টিলিয়ন"
+msgstr[0] "কুইন্টিলিয়ন"
+msgstr[1] "কুইন্টিলিয়ন"
 
 #: src/humanize/number.py:184
 msgid "sextillion"
 msgid_plural "sextillion"
-msgstr[0] "%d সেক্সটিলিয়ন"
-msgstr[1] "%d সেক্সটিলিয়ন"
+msgstr[0] "সেক্সটিলিয়ন"
+msgstr[1] "সেক্সটিলিয়ন"
 
 #: src/humanize/number.py:185
 msgid "septillion"
 msgid_plural "septillion"
-msgstr[0] "%d সেপটিলিয়ন"
-msgstr[1] "%d সেপটিলিয়ন"
+msgstr[0] "সেপটিলিয়ন"
+msgstr[1] "সেপটিলিয়ন"
 
 #: src/humanize/number.py:186
 msgid "octillion"
 msgid_plural "octillion"
-msgstr[0] "%d ওকটিলিয়ন"
-msgstr[1] "%d ওকটিলিয়ন"
+msgstr[0] "ওকটিলিয়ন"
+msgstr[1] "ওকটিলিয়ন"
 
 #: src/humanize/number.py:187
 msgid "nonillion"

--- a/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/ko_KR/LC_MESSAGES/humanize.po
@@ -148,8 +148,8 @@ msgstr[1] ""
 #: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
-msgstr[0] "%(value)s million"
-msgstr[1] "%(value)s million"
+msgstr[0] "million"
+msgstr[1] "million"
 
 #: src/humanize/number.py:180
 msgid "billion"
@@ -161,64 +161,64 @@ msgstr[1] "milliard"
 #, fuzzy
 msgid "trillion"
 msgid_plural "trillion"
-msgstr[0] "%(value)s billion"
-msgstr[1] "%(value)s billion"
+msgstr[0] "billion"
+msgstr[1] "billion"
 
 #: src/humanize/number.py:182
 #, fuzzy
 msgid "quadrillion"
 msgid_plural "quadrillion"
-msgstr[0] "%(value)s quadrillion"
-msgstr[1] "%(value)s quadrillion"
+msgstr[0] "quadrillion"
+msgstr[1] "quadrillion"
 
 #: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
-msgstr[0] "%(value)s quintillion"
-msgstr[1] "%(value)s quintillion"
+msgstr[0] "quintillion"
+msgstr[1] "quintillion"
 
 #: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
-msgstr[0] "%(value)s sextillion"
-msgstr[1] "%(value)s sextillion"
+msgstr[0] "sextillion"
+msgstr[1] "sextillion"
 
 #: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
-msgstr[0] "%(value)s septillion"
-msgstr[1] "%(value)s septillion"
+msgstr[0] "septillion"
+msgstr[1] "septillion"
 
 #: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
-msgstr[0] "%(value)s octillion"
-msgstr[1] "%(value)s octillion"
+msgstr[0] "octillion"
+msgstr[1] "octillion"
 
 #: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
-msgstr[0] "%(value)s nonillion"
-msgstr[1] "%(value)s nonillion"
+msgstr[0] "nonillion"
+msgstr[1] "nonillion"
 
 #: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
-msgstr[0] "%(value)s décillion"
-msgstr[1] "%(value)s décillion"
+msgstr[0] "décillion"
+msgstr[1] "décillion"
 
 #: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
-msgstr[0] "%(value)s gogol"
-msgstr[1] "%(value)s gogol"
+msgstr[0] "gogol"
+msgstr[1] "gogol"
 
 #: src/humanize/number.py:301
 msgid "zero"

--- a/src/humanize/locale/vi_VN/LC_MESSAGES/humanize.po
+++ b/src/humanize/locale/vi_VN/LC_MESSAGES/humanize.po
@@ -128,8 +128,8 @@ msgstr[1] "nghìn"
 #: src/humanize/number.py:179
 msgid "million"
 msgid_plural "million"
-msgstr[0] "%(value)s triệu"
-msgstr[1] "%(value)s triệu"
+msgstr[0] "triệu"
+msgstr[1] "triệu"
 
 #: src/humanize/number.py:180
 msgid "billion"
@@ -140,63 +140,63 @@ msgstr[1] "tỷ"
 #: src/humanize/number.py:181
 msgid "trillion"
 msgid_plural "trillion"
-msgstr[0] "%(value)s nghìn tỷ"
-msgstr[1] "%(value)s nghìn tỷ"
+msgstr[0] "nghìn tỷ"
+msgstr[1] "nghìn tỷ"
 
 #: src/humanize/number.py:182
 msgid "quadrillion"
 msgid_plural "quadrillion"
-msgstr[0] "%(value)s triệu tỷ"
-msgstr[1] "%(value)s triệu tỷ"
+msgstr[0] "triệu tỷ"
+msgstr[1] "triệu tỷ"
 
 #: src/humanize/number.py:183
 #, fuzzy
 msgid "quintillion"
 msgid_plural "quintillion"
-msgstr[0] "%(value)s tỷ tỷ"
-msgstr[1] "%(value)s tỷ tỷ"
+msgstr[0] "tỷ tỷ"
+msgstr[1] "tỷ tỷ"
 
 #: src/humanize/number.py:184
 #, fuzzy
 msgid "sextillion"
 msgid_plural "sextillion"
-msgstr[0] "%(value)s sextillion"
-msgstr[1] "%(value)s sextillion"
+msgstr[0] "sextillion"
+msgstr[1] "sextillion"
 
 #: src/humanize/number.py:185
 #, fuzzy
 msgid "septillion"
 msgid_plural "septillion"
-msgstr[0] "%(value)s septillion"
-msgstr[1] "%(value)s septillion"
+msgstr[0] "septillion"
+msgstr[1] "septillion"
 
 #: src/humanize/number.py:186
 #, fuzzy
 msgid "octillion"
 msgid_plural "octillion"
-msgstr[0] "%(value)s octillion"
-msgstr[1] "%(value)s octillion"
+msgstr[0] "octillion"
+msgstr[1] "octillion"
 
 #: src/humanize/number.py:187
 #, fuzzy
 msgid "nonillion"
 msgid_plural "nonillion"
-msgstr[0] "%(value)s nonillion"
-msgstr[1] "%(value)s nonillion"
+msgstr[0] "nonillion"
+msgstr[1] "nonillion"
 
 #: src/humanize/number.py:188
 #, fuzzy
 msgid "decillion"
 msgid_plural "decillion"
-msgstr[0] "%(value)s décillion"
-msgstr[1] "%(value)s décillion"
+msgstr[0] "décillion"
+msgstr[1] "décillion"
 
 #: src/humanize/number.py:189
 #, fuzzy
 msgid "googol"
 msgid_plural "googol"
-msgstr[0] "%(value)s gogol"
-msgstr[1] "%(value)s gogol"
+msgstr[0] "gogol"
+msgstr[1] "gogol"
 
 #: src/humanize/number.py:301
 msgid "zero"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -334,3 +334,14 @@ class TestActivate:
             humanize.i18n.deactivate()
 
         assert test_str == humanize.naturaltime(three_seconds)
+
+
+@pytest.mark.parametrize("locale", ["bn_BD", "ko_KR", "vi_VN"])
+def test_intword_unit_has_no_format_placeholder(locale: str) -> None:
+    """`intword` interpolates the unit verbatim, so it must carry no placeholder."""
+    try:
+        humanize.i18n.activate(locale)
+        for value in (1_000, 1_000_000, 1_000_000_000, 10**12, 10**15, 10**100):
+            assert "%" not in humanize.intword(value)
+    finally:
+        humanize.i18n.deactivate()


### PR DESCRIPTION
`intword` inserts the unit without any `%` substitution:

```python
singular, plural = human_powers[ordinal]
unit = _ngettext(singular, plural, math.ceil(rounded_value))
...
return f"{negative_prefix}{number} {unit}"
```

so a printf placeholder left in a translated unit is printed literally. The Bengali, Korean and Vietnamese catalogues still carry `%d` or `%(value)s` on the `thousand`…`googol` units:

```python
humanize.i18n.activate("bn_BD"); humanize.intword(1_500_000_000)
humanize.i18n.activate("vi_VN"); humanize.intword(1_200_000)
humanize.i18n.activate("ko_KR"); humanize.intword(1_200_000)
```

On `main`:

```
'1.5 %d বিলিয়ন'
'1.2 %(value)s triệu'
'1.2 %(value)s million'
```

With this PR:

```
'1.5 বিলিয়ন'
'1.2 triệu'
'1.2 million'
```

This strips the placeholder and the separator that follows it (a plain space or U+00A0) and leaves the translated words untouched.

Scope is deliberately narrow: only the twelve `intword` power msgids are changed. Placeholders elsewhere in these catalogues are substituted normally and are left alone — `naturaldelta`'s `"%d day"` and friends still need theirs. After the change, none of the 36 catalogues emits a placeholder for any of the twelve powers.

Added a parametrised regression test over the three locales, checking that `intword` never returns a `%` at any power. It fails 3/3 on `main` and passes here.

Two notes I did not act on, since both need a native speaker rather than a scripted edit:

- `ko_KR` renders several powers as the English words (`million`, `billion`), and its `trillion` entry reads `billion`.
- `ko_KR` and `vi_VN` also contain a couple of French leftovers (`décillion`, `gogol`).

Happy to split those out separately if you would like them addressed.
