### PR TITLE
Handle non-finite values in naturalsize

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 __lazy_modules__ = {"humanize.i18n", "math"}
 
-from math import log
+from math import isfinite, log
 
 from humanize.i18n import _gettext as _
+from humanize.number import _format_not_finite
 
 suffixes = {
     "decimal": (
@@ -90,6 +91,10 @@ def naturalsize(
 
     base = 1024 if (gnu or binary) else 1000
     bytes_ = float(value)
+    if not isfinite(bytes_):
+        # Match the rest of the library (see humanize.number): format NaN and
+        # infinities instead of crashing or emitting a bogus suffix like "inf QB".
+        return _format_not_finite(bytes_)
     abs_bytes = abs(bytes_)
 
     if abs_bytes == 1 and not gnu:

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 import humanize
@@ -103,3 +105,17 @@ def test_naturalsize(test_args: list[int] | list[int | bool], expected: str) -> 
         test_args[0] = f"-{test_args[0]}"
 
     assert humanize.naturalsize(*test_args) == "-" + expected
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (math.nan, "NaN"),
+        (math.inf, "+Inf"),
+        (-math.inf, "-Inf"),
+        ("nan", "NaN"),
+        ("inf", "+Inf"),
+        ("-inf", "-Inf"),
+    ],
+)
+def test_naturalsize_non_finite(value: float | str, expected: str) -> None:
+    assert humanize.naturalsize(value) == expected

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -106,6 +106,7 @@ def test_naturalsize(test_args: list[int] | list[int | bool], expected: str) -> 
 
     assert humanize.naturalsize(*test_args) == "-" + expected
 
+
 @pytest.mark.parametrize(
     "value, expected",
     [


### PR DESCRIPTION
Changes proposed in this pull request:

* `naturalsize()` now handles non-finite input consistently with the rest of the library. Every numeric formatter in `humanize.number` (`ordinal`, `intcomma`, `intword`, `apnumber`, `fractional`, `scientific`, `clamp`) already returns `"NaN"` / `"+Inf"` / `"-Inf"` for non-finite values via `_format_not_finite`. `naturalsize()` was the exception: `naturalsize(float("nan"))` raised `ValueError: cannot convert float NaN to integer`, and `naturalsize(float("inf"))` produced the bogus string `"inf QB"`. It now returns `"NaN"` / `"+Inf"` / `"-Inf"`.
* Added a parametrized `test_naturalsize_non_finite` covering `nan`, `inf`, `-inf` as both floats and strings; it fails on `main` and passes with this change.

### Before

```pycon
>>> import humanize
>>> humanize.naturalsize(float("nan"))
ValueError: cannot convert float NaN to integer
>>> humanize.naturalsize(float("inf"))
'inf QB'
```

### After

```pycon
>>> humanize.naturalsize(float("nan"))
'NaN'
>>> humanize.naturalsize(float("inf"))
'+Inf'
>>> humanize.naturalsize(float("-inf"))
'-Inf'
```

The fix reuses the existing `humanize.number._format_not_finite` helper so output matches the other formatters exactly, and guards right after the `float(value)` conversion. Finite values are unaffected.
