### PR TITLE
Defer importing `math` in `filesize.py`

### DIFF
--- a/src/humanize/filesize.py
+++ b/src/humanize/filesize.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = {"humanize.i18n", "math"}
-
-from math import log
+__lazy_modules__ = {"humanize.i18n"}
 
 from humanize.i18n import _gettext as _
 
@@ -97,6 +95,8 @@ def naturalsize(
 
     if abs_bytes < base:
         return f"{int(bytes_)}B" if gnu else _("%d Bytes") % int(bytes_)
+
+    from math import log
 
     exp = int(min(log(abs_bytes, base), len(suffix)))
     # The suffix is chosen from the unrounded byte count, but `format` rounds the


### PR DESCRIPTION
Alternative to and closes #393.

We were already deferring import of `math` in `number.py` (https://github.com/python-humanize/humanize/pull/238), but this was negating that.
